### PR TITLE
Add buildpack_key to result.json

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -116,8 +116,9 @@ var _ = Describe("Smelting", func() {
 				resultInfo, err := ioutil.ReadFile(resultLocation)
 				Ω(err).ShouldNot(HaveOccurred())
 				expectedJSON := `{
-			"detected_buildpack": "Always Matching"
-		}`
+					"detected_buildpack": "Always Matching",
+					"buildpack_key": "always-detects"
+				}`
 
 				Ω(resultInfo).Should(MatchJSON(expectedJSON))
 			})


### PR DESCRIPTION
Save information about the admin buildpack used for staging in `result.json` so the stager can send it back to the CC in the staging response.

Depends on cloudfoundry-incubator/runtime-schema/pull/6
