### PR TITLE
Improve clarity of "no start command" error message

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -259,7 +259,8 @@ var _ = Describe("Building", func() {
 
 				It("displays an error and returns the Procfile data without web", func() {
 					session := builder()
-					Eventually(session.Err).Should(gbytes.Say("No start command detected"))
+					Eventually(session.Err).Should(gbytes.Say("No start command specified by buildpack or via Procfile."))
+					Eventually(session.Err).Should(gbytes.Say("App will not start unless a command is provided at runtime."))
 					Eventually(session).Should(gexec.Exit(0))
 
 					Expect(resultJSON()).To(MatchJSON(`{
@@ -282,7 +283,8 @@ var _ = Describe("Building", func() {
 
 			It("fails", func() {
 				session := builder()
-				Eventually(session.Err).Should(gbytes.Say("No start command detected"))
+				Eventually(session.Err).Should(gbytes.Say("No start command specified by buildpack or via Procfile."))
+				Eventually(session.Err).Should(gbytes.Say("App will not start unless a command is provided at runtime."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 		})

--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -89,7 +89,8 @@ func (runner *Runner) Run() error {
 	}
 
 	if releaseInfo.DefaultProcessTypes["web"] == "" {
-		printError("No start command detected; command must be provided at runtime")
+		printError("No start command specified by buildpack or via Procfile.")
+		printError("App will not start unless a command is provided at runtime.")
 	}
 
 	tarPath, err := exec.LookPath("tar")


### PR DESCRIPTION
- Currently, the error message can lead the user to believe that no
start command was specified at all (via `-c` or the `command:` key in
the manifest). This clarifies that the buildpack and Procfile did not
provide start commands.

- https://www.pivotaltracker.com/story/show/128507135