### PR TITLE
Fix cf push with -b fails

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -255,6 +255,25 @@ var _ = Describe("Building", func() {
 				files = strings.Split(string(result), "\n")
 			})
 
+			Describe("the result.json, which is used to communicate back to the stager", func() {
+				BeforeEach(func() {
+					buildpackOrder = "always-detects"
+					cpBuildpack("always-detects")
+					cp(filepath.Join(appFixtures, "bash-app", "app.sh"), buildDir)
+				})
+				It("exists, and contains the final buildpack key", func() {
+					Expect(resultJSON()).To(MatchJSON(`{
+						"process_types":{"web":"the start command"},
+						"lifecycle_type": "buildpack",
+						"lifecycle_metadata":{
+							"detected_buildpack": "",
+							"buildpack_key": "always-detects"
+						},
+						"execution_metadata": ""
+				}`))
+				})
+			})
+
 			Context("final buildpack does not contain a finalize script", func() {
 				BeforeEach(func() {
 					buildpackOrder = "always-detects-creates-build-artifacts,always-detects,also-always-detects"


### PR DESCRIPTION
After running all the buildpacks, the builder fills in a `result.json` with a `buildpack_key` containing the final buildpack that ran. As of 556939b0 this was not getting filled in when `skipDetect=true`

Signed-off-by: Amin Jamali <ajamali@pivotal.io>