### PR TITLE
Merge procfile with processes from buildpack [#149324085]

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -538,7 +538,7 @@ var _ = Describe("Building", func() {
 		})
 	})
 
-	Context("with a buildpack that does not determine a start command", func() {
+	Context("with a buildpack that has no commands", func() {
 		BeforeEach(func() {
 			buildpackOrder = "release-without-command"
 			cpBuildpack("release-without-command")
@@ -601,6 +601,159 @@ var _ = Describe("Building", func() {
 				Eventually(session.Err).Should(gbytes.Say("No start command specified by buildpack or via Procfile."))
 				Eventually(session.Err).Should(gbytes.Say("App will not start unless a command is provided at runtime."))
 				Eventually(session).Should(gexec.Exit(0))
+			})
+		})
+	})
+
+	Context("with a buildpack that determines a start web-command", func() {
+		BeforeEach(func() {
+			buildpackOrder = "always-detects"
+			cpBuildpack("always-detects")
+		})
+
+		Context("when the app has a Procfile", func() {
+			Context("with web defined", func() {
+				JustBeforeEach(func() {
+					Eventually(builder(), 5*time.Second).Should(gexec.Exit(0))
+				})
+
+				BeforeEach(func() {
+					cp(path.Join(appFixtures, "with-procfile-with-web", "Procfile"), buildDir)
+				})
+
+				It("merges the Procfile and the buildpack for execution_metadata", func() {
+					Expect(resultJSON()).To(MatchJSON(`{
+						"process_types":{"web":"procfile-provided start-command"}, 
+						"lifecycle_type": "buildpack",
+						"lifecycle_metadata":{
+							"detected_buildpack": "Always Matching",
+							"buildpack_key": "always-detects"
+						},
+						"execution_metadata": ""
+					}`))
+				})
+			})
+
+			Context("without web", func() {
+				JustBeforeEach(func() {
+					Eventually(builder(), 5*time.Second).Should(gexec.Exit(0))
+				})
+
+				BeforeEach(func() {
+					cp(path.Join(appFixtures, "with-procfile", "Procfile"), buildDir)
+				})
+
+				It("merges the Procfile but uses the buildpack for execution_metadata", func() {
+
+					Expect(resultJSON()).To(MatchJSON(`{
+						"process_types":{"spider":"bogus command", "web":"the start command"},
+						"lifecycle_type": "buildpack",
+						"lifecycle_metadata": {
+							"detected_buildpack": "Always Matching",
+							"buildpack_key": "always-detects"
+						},
+						"execution_metadata": ""
+					}`))
+				})
+			})
+		})
+
+		Context("and the app has no Procfile", func() {
+
+			JustBeforeEach(func() {
+				Eventually(builder(), 5*time.Second).Should(gexec.Exit(0))
+			})
+
+			BeforeEach(func() {
+				cp(path.Join(appFixtures, "bash-app", "app.sh"), buildDir)
+			})
+
+			It("merges the Procfile and the buildpack for execution_metadata", func() {
+				Expect(resultJSON()).To(MatchJSON(`{
+						"process_types":{"web":"the start command"}, 
+						"lifecycle_type": "buildpack",
+						"lifecycle_metadata":{
+							"detected_buildpack": "Always Matching",
+							"buildpack_key": "always-detects"
+						},
+						"execution_metadata": ""
+					}`))
+			})
+		})
+	})
+
+	Context("with a buildpack that determines a start non-web-command", func() {
+		BeforeEach(func() {
+			buildpackOrder = "always-detects-non-web"
+			cpBuildpack("always-detects-non-web")
+		})
+
+		Context("when the app has a Procfile", func() {
+			Context("with web defined", func() {
+				JustBeforeEach(func() {
+					Eventually(builder(), 5*time.Second).Should(gexec.Exit(0))
+				})
+
+				BeforeEach(func() {
+					cp(path.Join(appFixtures, "with-procfile-with-web", "Procfile"), buildDir)
+				})
+
+				It("merges the Procfile for execution_metadata", func() {
+					Expect(resultJSON()).To(MatchJSON(`{
+						"process_types":{"web":"procfile-provided start-command", "nonweb":"start nonweb buildpack"},
+						"lifecycle_type": "buildpack",
+						"lifecycle_metadata":{
+							"detected_buildpack": "Always Detects Non-Web",
+							"buildpack_key": "always-detects-non-web"
+						},
+						"execution_metadata": ""
+					}`))
+				})
+			})
+
+			Context("without web", func() {
+				BeforeEach(func() {
+					cp(path.Join(appFixtures, "with-procfile", "Procfile"), buildDir)
+				})
+
+				It("displays an error and returns the Procfile data without web", func() {
+					session := builder()
+					Eventually(session.Err).Should(gbytes.Say("No start command specified by buildpack or via Procfile."))
+					Eventually(session.Err).Should(gbytes.Say("App will not start unless a command is provided at runtime."))
+					Eventually(session).Should(gexec.Exit(0))
+
+					Expect(resultJSON()).To(MatchJSON(`{
+						"process_types":{"spider":"bogus command", "nonweb":"start nonweb buildpack"},
+						"lifecycle_type": "buildpack",
+						"lifecycle_metadata": {
+							"detected_buildpack": "Always Detects Non-Web",
+							"buildpack_key": "always-detects-non-web"
+						},
+						"execution_metadata": ""
+					}`))
+				})
+			})
+		})
+
+		Context("and the app has no Procfile", func() {
+			BeforeEach(func() {
+				cp(path.Join(appFixtures, "bash-app", "app.sh"), buildDir)
+			})
+
+			It("fails", func() {
+				session := builder()
+				Eventually(session.Err).Should(gbytes.Say("No start command specified by buildpack or via Procfile."))
+				Eventually(session.Err).Should(gbytes.Say("App will not start unless a command is provided at runtime."))
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(resultJSON()).To(MatchJSON(`{
+						"process_types":{"nonweb":"start nonweb buildpack"},
+						"lifecycle_type": "buildpack",
+						"lifecycle_metadata": {
+							"detected_buildpack": "Always Detects Non-Web",
+							"buildpack_key": "always-detects-non-web"
+						},
+						"execution_metadata": ""
+					}`))
 			})
 		})
 	})

--- a/builder/fixtures/buildpacks/always-detects-non-web/bin/compile
+++ b/builder/fixtures/buildpacks/always-detects-non-web/bin/compile
@@ -1,0 +1,10 @@
+#!/bin/bash
+# vim: set ft=sh
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+
+echo WOO
+echo always-detects-buildpack > $BUILD_DIR/compiled
+echo always-detects-buildpack > $CACHE_DIR/compiled
+

--- a/builder/fixtures/buildpacks/always-detects-non-web/bin/detect
+++ b/builder/fixtures/buildpacks/always-detects-non-web/bin/detect
@@ -1,0 +1,5 @@
+#!/bin/bash
+# vim: set ft=sh
+
+echo Always Detects Non-Web
+exit 0

--- a/builder/fixtures/buildpacks/always-detects-non-web/bin/release
+++ b/builder/fixtures/buildpacks/always-detects-non-web/bin/release
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat <<EOF
+---
+default_process_types:
+  nonweb: start nonweb buildpack
+EOF

--- a/builder/fixtures/buildpacks/always-detects-non-web/bin/supply
+++ b/builder/fixtures/buildpacks/always-detects-non-web/bin/supply
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+DEP_DIR=$3
+SUB_DIR=$4
+
+
+echo SUPPLYING
+
+if [ -e "$CACHE_DIR/old-supply" ]; then
+  contents=$(cat "$CACHE_DIR/old-supply")
+else
+  contents="always-detects-buildpack"
+fi
+
+echo $contents > $CACHE_DIR/supplied
+echo $contents > $DEP_DIR/$SUB_DIR/supplied

--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -427,7 +427,13 @@ func (runner *Runner) release(buildpackDir string, startCommands map[string]stri
 	}
 
 	if len(startCommands) > 0 {
-		parsedRelease.DefaultProcessTypes = startCommands
+		if len(parsedRelease.DefaultProcessTypes) == 0 {
+			parsedRelease.DefaultProcessTypes = startCommands
+		} else {
+			for k, v := range startCommands {
+				parsedRelease.DefaultProcessTypes[k] = v
+			}
+		}
 	}
 
 	return parsedRelease, nil


### PR DESCRIPTION
Today processes are deteremined as an either/or. If no Procfile is supplied, then we take the buildpack list. If a Procfile is supplied then we ignore the buildpack list.
We would prefer to enable a merge workflow. This allows app developers to provide a Procfile that adds worker functionality to a web application, while still getting start command auto detection from the buildpack.

Story: https://www.pivotaltracker.com/story/show/149324085
Signed-off-by: Annie Sing <asing@pivotal.io>