### PR TITLE
Don't ignore error from zip buildpack download

### DIFF
--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -204,17 +204,20 @@ func (runner *Runner) downloadBuildpacks() error {
 
 		destination := runner.config.BuildpackPath(buildpackName)
 
+		var downloadErr error
 		if IsZipFile(buildpackURL.Path) {
+			var size uint64
+
 			zipDownloader := NewZipDownloader(runner.config.SkipCertVerify())
-			size, err := zipDownloader.DownloadAndExtract(buildpackURL, destination)
-			if err == nil {
+			size, downloadErr = zipDownloader.DownloadAndExtract(buildpackURL, destination)
+			if downloadErr == nil {
 				fmt.Printf("Downloaded buildpack `%s` (%s)\n", buildpackURL.String(), bytefmt.ByteSize(size))
 			}
 		} else {
-			err = GitClone(*buildpackURL, destination)
+			downloadErr = GitClone(*buildpackURL, destination)
 		}
-		if err != nil {
-			return err
+		if downloadErr != nil {
+			return downloadErr
 		}
 	}
 


### PR DESCRIPTION
The error returned by zipDownloader was only scoped to the IsZipFile
block. So any error it would returned would be ignored and
downloadBuildpacks would return success

This fixes https://github.com/cloudfoundry/buildpackapplifecycle/issues/24