### PR TITLE
Improve launcher failure messages

### DIFF
--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -204,10 +204,10 @@ var _ = Describe("Launcher", func() {
 		ItExecutesTheCommandWithTheRightEnvironment()
 	})
 
-	var ItPrintsUsageInformation = func() {
-		It("prints usage information", func() {
+	var ItPrintsMissingStartCommandInformation = func() {
+		It("fails and reports no start command", func() {
 			Eventually(session).Should(gexec.Exit(1))
-			Eventually(session.Err).Should(gbytes.Say("Usage: launcher <app directory> <start command> <metadata>"))
+			Eventually(session.Err).Should(gbytes.Say("launcher: no start command specified or detected in droplet"))
 		})
 	}
 
@@ -222,7 +222,7 @@ var _ = Describe("Launcher", func() {
 		})
 
 		Context("when the app package does not contain staging_info.yml", func() {
-			ItPrintsUsageInformation()
+			ItPrintsMissingStartCommandInformation()
 		})
 
 		Context("when the app package has a staging_info.yml", func() {
@@ -232,7 +232,7 @@ var _ = Describe("Launcher", func() {
 					writeStagingInfo(extractDir, "detected_buildpack: Ruby")
 				})
 
-				ItPrintsUsageInformation()
+				ItPrintsMissingStartCommandInformation()
 			})
 
 			Context("when it contains a start command", func() {
@@ -278,7 +278,11 @@ var _ = Describe("Launcher", func() {
 			}
 		})
 
-		ItPrintsUsageInformation()
+		It("fails with an indication that too few arguments were passed", func() {
+			Eventually(session).Should(gexec.Exit(1))
+			Eventually(session.Err).Should(gbytes.Say("launcher: received only 2 arguments\n"))
+			Eventually(session.Err).Should(gbytes.Say("Usage: launcher <app-directory> <start-command> <metadata>"))
+		})
 	})
 })
 

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -15,7 +15,9 @@ import (
 
 func main() {
 	if len(os.Args) < 4 {
-		exitWithUsage()
+		fmt.Fprintf(os.Stderr, "%s: received only %d arguments\n", os.Args[0], len(os.Args)-1)
+		fmt.Fprintf(os.Stderr, "Usage: %s <app-directory> <start-command> <metadata>", os.Args[0])
+		os.Exit(1)
 	}
 
 	dir := os.Args[1]
@@ -72,16 +74,12 @@ func main() {
 	}
 
 	if command == "" {
-		exitWithUsage()
+		fmt.Fprintf(os.Stderr, "%s: no start command specified or detected in droplet", os.Args[0])
+		os.Exit(1)
 	}
 
 	runtime.GOMAXPROCS(1)
 	runProcess(dir, command)
-}
-
-func exitWithUsage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s <app directory> <start command> <metadata>", os.Args[0])
-	os.Exit(1)
 }
 
 type stagingInfo struct {


### PR DESCRIPTION
Failure messages now distinguish between invoking the launcher with too few arguments and the launcher being unable to determine a start command from arguments and the staging info file.

---

For example, this improves the experience of pushing a "plain old" Ruby-buildpack app without a start command or Procfile. Before, the app would fail to run with this message on standard error:

```
2017-08-31T22:01:28.73-0700 [APP/PROC/WEB/0] ERR Usage: /tmp/lifecycle/launcher <app directory> <start command> <metadata>
```

With this change, it fails with:

```
2017-08-31T22:12:54.41-0700 [APP/PROC/WEB/0] ERR /tmp/lifecycle/launcher: no start command specified or detected in droplet
```

(@cppforlife and I ran into this error today.)