### PR TITLE
BAL works on windows2012R2

### DIFF
--- a/builder/builder_helpers_test.go
+++ b/builder/builder_helpers_test.go
@@ -1,0 +1,23 @@
+// +build !windows2012R2
+
+package main_test
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+func buildBuilder() string {
+	builder, err := gexec.Build("code.cloudfoundry.org/buildpackapplifecycle/builder")
+	Expect(err).NotTo(HaveOccurred())
+
+	return builder
+}
+
+func downloadTar() string {
+	return ""
+}
+
+func copyTar(destDir string) {
+	return
+}

--- a/builder/builder_helpers_windows2012R2_test.go
+++ b/builder/builder_helpers_windows2012R2_test.go
@@ -1,0 +1,60 @@
+// +build windows,windows2012R2
+
+package main_test
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+func buildBuilder() string {
+	builder, err := gexec.Build("code.cloudfoundry.org/buildpackapplifecycle/builder", "-tags=windows2012R2")
+	Expect(err).NotTo(HaveOccurred())
+
+	return builder
+}
+
+func downloadTar() string {
+	tarUrl := os.Getenv("TAR_URL")
+	Expect(tarUrl).NotTo(BeEmpty(), "TAR_URL environment variable must be set")
+
+	resp, err := http.Get(tarUrl)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer resp.Body.Close()
+
+	tmpDir, err := ioutil.TempDir("", "tar")
+	Expect(err).NotTo(HaveOccurred())
+
+	tarExePath := filepath.Join(tmpDir, "tar.exe")
+	f, err := os.OpenFile(tarExePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	Expect(err).NotTo(HaveOccurred())
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	return tarExePath
+}
+
+func copyTar(destDir string) {
+	f, err := os.Open(tarPath)
+	Expect(err).NotTo(HaveOccurred())
+	defer f.Close()
+
+	Expect(os.MkdirAll(destDir, 0755)).To(Succeed())
+
+	d, err := os.OpenFile(filepath.Join(destDir, "tar.exe"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	Expect(err).NotTo(HaveOccurred())
+	defer d.Close()
+
+	_, err = io.Copy(d, f)
+	Expect(err).NotTo(HaveOccurred())
+	return
+}

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -61,6 +61,8 @@ var _ = Describe("Building", func() {
 		buildDir, err = ioutil.TempDir(tmpDir, "building-app")
 		Expect(err).NotTo(HaveOccurred())
 
+		copyTar(filepath.Join(tmpDir, "tmp", "lifecycle"))
+
 		buildpacksDir, err = ioutil.TempDir(tmpDir, "building-buildpacks")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -104,6 +106,7 @@ var _ = Describe("Building", func() {
 
 		env := os.Environ()
 		builderCmd.Env = append(env, "TMPDIR="+tmpDir)
+		builderCmd.Dir = tmpDir
 	})
 
 	resultJSON := func() []byte {

--- a/builder_config_path.go
+++ b/builder_config_path.go
@@ -1,0 +1,9 @@
+// +build !windows2012R2
+
+package buildpackapplifecycle
+
+import "path/filepath"
+
+func (s LifecycleBuilderConfig) getPath(path string) string {
+	return filepath.Clean(path)
+}

--- a/builder_config_path_windows2012R2.go
+++ b/builder_config_path_windows2012R2.go
@@ -1,0 +1,15 @@
+// +build windows,windows2012R2
+
+package buildpackapplifecycle
+
+import (
+	"path/filepath"
+)
+
+func (s LifecycleBuilderConfig) getPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	return filepath.Join(s.workingDir, path)
+}

--- a/builder_config_prefix_test.go
+++ b/builder_config_prefix_test.go
@@ -1,0 +1,7 @@
+// +build !windows2012R2
+
+package buildpackapplifecycle_test
+
+func pathPrefix() string {
+	return "/"
+}

--- a/builder_config_prefix_windows2012R2_test.go
+++ b/builder_config_prefix_windows2012R2_test.go
@@ -1,0 +1,16 @@
+// +build windows,windows2012R2
+
+package buildpackapplifecycle_test
+
+import (
+	"os"
+
+	. "github.com/onsi/gomega"
+)
+
+func pathPrefix() string {
+	workingDir, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred())
+
+	return workingDir
+}

--- a/buildpackrunner/find_tar.go
+++ b/buildpackrunner/find_tar.go
@@ -1,0 +1,13 @@
+// +build !windows2012R2
+
+package buildpackrunner
+
+import "os/exec"
+
+func (runner *Runner) findTar() (string, error) {
+	tarPath, err := exec.LookPath("tar")
+	if err != nil {
+		return "", err
+	}
+	return tarPath, nil
+}

--- a/buildpackrunner/find_tar_windows2012R2.go
+++ b/buildpackrunner/find_tar_windows2012R2.go
@@ -1,0 +1,9 @@
+// +build windows,windows2012R2
+
+package buildpackrunner
+
+import "path/filepath"
+
+func (runner *Runner) findTar() (string, error) {
+	return filepath.Join(filepath.Dir(runner.config.Path()), "tar.exe"), nil
+}

--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -110,7 +110,7 @@ func (runner *Runner) Run() (string, error) {
 		printError("App will not start unless a command is provided at runtime.")
 	}
 
-	tarPath, err := exec.LookPath("tar")
+	tarPath, err := runner.findTar()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
In order for Diego instance identity credentials to work on windows2012R2, it will need to use the BAL instead of the .NET WAL.

There are two main changes that need to be made in order for the BAL to
work on windows2012R2:

  1. Because of the way "containers" are implemented (directories in
  c:\containerizer), we need to prepend the working directory of the
  process running builder.exe to all of the builder config paths

  2. We can't assume that tar.exe is on the PATH. Instead, we will
  assume that it is next to the builder.exe file (i.e. in the same
  directory as all the other lifecycle binaries)

As of this PR, there are now three ways to build the builder:

  1. For linux
  2. GOOS=windows -tags=windows2012R2 // for windows2012R2
  3. GOOS=windows                     // for windows2016

When running the builder tests for windows2012R2, the environment
variable TAR_URL must be set. The test suite will download this file and
place it next to the builder.exe built by gexec.Build

The tar.exe files that will be included in diego-release can be found
here: https://greenhouse.ci.cf-app.com/teams/main/pipelines/tar/resources/s3-bucket

No changes are required to the launcher.

[#151173124]

Signed-off-by: Sam Smith <sesmith177@gmail.com>