### PR TITLE
App subprocess stdout/err captured by launcher

### DIFF
--- a/launcher/fixtures/hello/hello.go
+++ b/launcher/fixtures/hello/hello.go
@@ -1,6 +1,8 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func main() {
 	fmt.Println("app is running")


### PR DESCRIPTION
Stdout/error from subprocesses the app spawned was not being captured by the launcher. We adjusted the arguments to the `CreateProcess` syscall accordingly. We also backfilled a missing exit code test and test for executable with spaces in path (on Windows only).
