### PR TITLE
Add support for .profile.bat, .profile.d, and profile.d on Windows

### DIFF
--- a/launcher/profile/profile.go
+++ b/launcher/profile/profile.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package profile
+
+import (
+	"io"
+)
+
+func ProfileEnv(appDir, tempDir string, stdout io.Writer, stderr io.Writer) ([]string, error) {
+	panic("not implemented for non-Windows OS")
+}

--- a/launcher/profile/profile_suite_test.go
+++ b/launcher/profile/profile_suite_test.go
@@ -1,0 +1,13 @@
+package profile_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestProfile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Buildpack-Lifecycle-Launcher-Profile Suite")
+}

--- a/launcher/profile/profile_test.go
+++ b/launcher/profile/profile_test.go
@@ -1,0 +1,190 @@
+package profile_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"code.cloudfoundry.org/buildpackapplifecycle/launcher/profile"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Profile", func() {
+	Context("ProfileEnv", func() {
+		var (
+			rootDir string
+			appDir  string
+			tmpDir  string
+		)
+
+		BeforeEach(func() {
+			if runtime.GOOS != "windows" {
+				Skip("only run on Windows")
+			}
+			var err error
+			rootDir, err = ioutil.TempDir("", "root")
+			Expect(err).NotTo(HaveOccurred())
+			appDir = filepath.Join(rootDir, "app")
+			Expect(os.MkdirAll(appDir, 0755)).To(Succeed())
+			tmpDir, err = ioutil.TempDir("", "launcher-tmp")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(rootDir)
+			os.RemoveAll(tmpDir)
+		})
+
+		Context("there is a .profile.bat script", func() {
+			It("has the env variable", func() {
+				writeToFile("set FOO=bar\n", filepath.Join(appDir, ".profile.bat"))
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(envs).To(ContainElement("FOO=bar"))
+			})
+
+			It("has the env variable with spaces", func() {
+				writeToFile("set FOO=b ar\n", filepath.Join(appDir, ".profile.bat"))
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(envs).To(ContainElement("FOO=b ar"))
+			})
+
+			It("has the env variable with json", func() {
+				writeToFile(`set FOO={ "a": "b", "c": "d"}`+"\n", filepath.Join(appDir, ".profile.bat"))
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envs).To(ContainElement(`FOO={ "a": "b", "c": "d"}`))
+			})
+
+			It("sets multiple env variable", func() {
+				writeToFile("set FOO=bar\nset BAR=foo", filepath.Join(appDir, ".profile.bat"))
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(envs).To(ContainElement("FOO=bar"))
+				Expect(envs).To(ContainElement("BAR=foo"))
+			})
+
+			It("only returns strings of the form var=val", func() {
+				writeToFile("echo hi from a batch file\nset BAR=foo", filepath.Join(appDir, ".profile.bat"))
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, v := range envs {
+					subs := strings.SplitN(v, "=", 2)
+					Expect(len(subs)).To(Equal(2), fmt.Sprintf("%+v\n", v))
+					Expect(subs[0]).NotTo(Equal(""))
+				}
+			})
+
+			It("captures stdout and stderr", func() {
+				writeToFile("echo this is stdout\n echo this is stderr 1>&2", filepath.Join(appDir, ".profile.bat"))
+				stdOut := new(bytes.Buffer)
+				stdErr := new(bytes.Buffer)
+				_, err := profile.ProfileEnv(appDir, tmpDir, stdOut, stdErr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.TrimSpace(stdOut.String())).To(Equal("this is stdout"))
+				Expect(strings.TrimSpace(stdErr.String())).To(Equal("this is stderr"))
+			})
+
+			It("errors if the .profile.bat errors", func() {
+				writeToFile("exit 333\n", filepath.Join(appDir, ".profile.bat"))
+				_, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err.Error()).To(Equal("running profile scripts failed: exit status 333"))
+			})
+		})
+
+		Context("there is also a .profile.d directory with multiple scripts", func() {
+			BeforeEach(func() {
+				Expect(os.MkdirAll(filepath.Join(appDir, ".profile.d"), 0755)).To(Succeed())
+				writeToFile("set FOO=%FOO%;bar2\n", filepath.Join(appDir, ".profile.d", "bp2.bat"))
+				writeToFile("set FOO=bar1\n", filepath.Join(appDir, ".profile.d", "bp1.bat"))
+				writeToFile("set FOO=%FOO%;bar3\n", filepath.Join(appDir, ".profile.bat"))
+			})
+
+			It("they all run in order", func() {
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envs).To(ContainElement("FOO=bar1;bar2;bar3"))
+			})
+
+			It("errors if the a .profile.d script errors", func() {
+				writeToFile("exit 333\n", filepath.Join(appDir, ".profile.d", "error.bat"))
+				_, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err.Error()).To(Equal("running profile scripts failed: exit status 333"))
+			})
+		})
+
+		Context("there is also a .profile.d directory with multiple scripts", func() {
+			BeforeEach(func() {
+				Expect(os.MkdirAll(filepath.Join(rootDir, "profile.d"), 0755)).To(Succeed())
+				Expect(os.MkdirAll(filepath.Join(appDir, ".profile.d"), 0755)).To(Succeed())
+
+				writeToFile("set FOO=bar1\n", filepath.Join(rootDir, "profile.d", "bp2.bat"))
+				writeToFile("set FOO=%FOO%;bar2\n", filepath.Join(appDir, ".profile.d", "bp1.bat"))
+				writeToFile("set FOO=%FOO%;bar3\n", filepath.Join(appDir, ".profile.bat"))
+			})
+
+			It("they all run in order", func() {
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envs).To(ContainElement("FOO=bar1;bar2;bar3"))
+			})
+
+			It("errors if the a .profile.d script errors", func() {
+				writeToFile("exit 333\n", filepath.Join(rootDir, "profile.d", "error.bat"))
+				_, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err.Error()).To(Equal("running profile scripts failed: exit status 333"))
+			})
+		})
+
+		Context("the environment variables overwrite eachother", func() {
+			BeforeEach(func() {
+				Expect(os.MkdirAll(filepath.Join(rootDir, "profile.d"), 0755)).To(Succeed())
+				Expect(os.MkdirAll(filepath.Join(appDir, ".profile.d"), 0755)).To(Succeed())
+
+				writeToFile("set FOO=bar1\n", filepath.Join(rootDir, "profile.d", "bp2.bat"))
+				writeToFile("set FOO=bar2\n", filepath.Join(appDir, ".profile.d", "bp1.bat"))
+				writeToFile("set FOO=bar3\n", filepath.Join(appDir, ".profile.bat"))
+			})
+
+			It("the .profile.bat script wins", func() {
+				envs, err := profile.ProfileEnv(appDir, tmpDir, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envs).To(ContainElement("FOO=bar3"))
+			})
+		})
+
+		Context("temp dir does not exist", func() {
+			It("errors", func() {
+				_, err := profile.ProfileEnv(appDir, filepath.Join(tmpDir, "not-exist"), GinkgoWriter, GinkgoWriter)
+				Expect(err.Error()).To(ContainSubstring("invalid temp dir"))
+				Expect(err.Error()).To(ContainSubstring("The system cannot find the file specified"))
+			})
+		})
+
+		Context("temp dir is not a directory", func() {
+			BeforeEach(func() {
+				Expect(ioutil.WriteFile(filepath.Join(tmpDir, "some-file"), []byte("xxx"), 0644)).To(Succeed())
+			})
+
+			It("errors", func() {
+				_, err := profile.ProfileEnv(appDir, filepath.Join(tmpDir, "some-file"), GinkgoWriter, GinkgoWriter)
+				Expect(err.Error()).To(Equal("temp dir must be a directory"))
+			})
+		})
+	})
+})
+
+func writeToFile(content, file string) {
+	err := ioutil.WriteFile(file, []byte(content), 0755)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}

--- a/launcher/profile/profile_windows.go
+++ b/launcher/profile/profile_windows.go
@@ -1,0 +1,57 @@
+// +build windows
+
+package profile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func ProfileEnv(appDir, tempDir string, stdout io.Writer, stderr io.Writer) ([]string, error) {
+	fi, err := os.Stat(tempDir)
+	if err != nil {
+		return nil, fmt.Errorf("invalid temp dir: %s", err.Error())
+	} else if !fi.IsDir() {
+		return nil, errors.New("temp dir must be a directory")
+	}
+
+	envOutputFile := filepath.Join(tempDir, "launcher.env")
+	defer os.Remove(envOutputFile)
+
+	batchFileLines := []string{
+		"@echo off",
+		fmt.Sprintf("cd %s", appDir),
+		`(for /r %i in (..\profile.d\*) do %i)`,
+		`(for /r %i in (.profile.d\*) do %i)`,
+		`(if exist .profile.bat ( .profile.bat ))`,
+		fmt.Sprintf("set > %s", envOutputFile),
+	}
+
+	cmd := exec.Command("cmd", "/c", strings.Join(batchFileLines, " & "))
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return []string{}, fmt.Errorf("running profile scripts failed: %s", err.Error())
+	}
+	out, err := ioutil.ReadFile(envOutputFile)
+	if err != nil {
+		return []string{}, err
+	}
+
+	cleanedVars := []string{}
+	vars := strings.Split(string(out), "\n")
+	for _, v := range vars {
+		if v != "" {
+			cleanedVars = append(cleanedVars, strings.TrimSpace(v))
+		}
+	}
+
+	return cleanedVars, nil
+}


### PR DESCRIPTION
This adds support to the launcher for running batch scripts from the profile.d and
.profile.d directories, and a .profile.bat script in the app directory
before starting the app on Windows.

Note that only .bat files are supported

The launcher will run all of the required batch scripts in one process,
extract the environment after all have run, and pass that environment to
the CreateProcess call that launches the app