### PR TITLE
Fix Windows newline environment variables

### DIFF
--- a/getenv/getenv.go
+++ b/getenv/getenv.go
@@ -33,7 +33,8 @@ func main() {
 
 	bytes, err := json.Marshal(cleanedEnviron)
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "cannot marshal environmental variables to JSON: %s", cleanedEnviron)
+		os.Exit(1)
 	}
 
 	err = ioutil.WriteFile(outputFile, bytes, 0644)

--- a/getenv/getenv.go
+++ b/getenv/getenv.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+var outputFile string
+
+func init() {
+	flag.StringVar(&outputFile, "output", "", "output file for the environment")
+}
+
+func main() {
+	flag.Parse()
+
+	if outputFile == "" {
+		fmt.Fprintln(os.Stderr, "output file must not be empty")
+		os.Exit(1)
+	}
+
+	cleanedEnviron := []string{}
+	for _, v := range os.Environ() {
+		subs := strings.SplitN(v, "=", 2)
+		if subs[0] != "" {
+			cleanedEnviron = append(cleanedEnviron, v)
+		}
+	}
+
+	bytes, err := json.Marshal(cleanedEnviron)
+	if err != nil {
+		panic(err)
+	}
+
+	err = ioutil.WriteFile(outputFile, bytes, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot write to output file: '%s'\n", outputFile)
+		os.Exit(1)
+	}
+}

--- a/getenv/getenv_suite_test.go
+++ b/getenv/getenv_suite_test.go
@@ -1,7 +1,6 @@
-package profile_test
+package main_test
 
 import (
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -11,9 +10,9 @@ import (
 
 var getenv string
 
-func TestProfile(t *testing.T) {
+func TestGetEnv(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Buildpack-Lifecycle-Launcher-Profile Suite")
+	RunSpecs(t, "Getenv")
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
@@ -21,9 +20,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 	return []byte(getenvPath)
 }, func(getenvExe []byte) {
-	if runtime.GOOS == "windows" {
-		getenv = string(getenvExe)
-	}
+	getenv = string(getenvExe)
 })
 
 var _ = SynchronizedAfterSuite(func() {

--- a/getenv/getenv_test.go
+++ b/getenv/getenv_test.go
@@ -1,0 +1,79 @@
+package main_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Getenv", func() {
+	var (
+		outputDir string
+		fileEnv   string
+		cmd       *exec.Cmd
+	)
+
+	BeforeEach(func() {
+		var err error
+		outputDir, err = ioutil.TempDir("", "getenv")
+		Expect(err).ToNot(HaveOccurred())
+		fileEnv = filepath.Join(outputDir, "file.env")
+
+		cmd = exec.Command(getenv, "-output", fileEnv)
+		cmd.Env = append(os.Environ(), "FOO=bar")
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(outputDir)).To(Succeed())
+	})
+
+	It("writes the current environment variables to a file", func() {
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(0))
+
+		Expect(fileEnv).To(BeAnExistingFile())
+
+		envs, err := ioutil.ReadFile(fileEnv)
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanedVars := []string{}
+		err = json.Unmarshal(envs, &cleanedVars)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(cleanedVars).To(ContainElement("FOO=bar"))
+	})
+
+	Context("when no output flag is passed", func() {
+		BeforeEach(func() {
+			cmd.Args = []string{}
+		})
+
+		It("fails with a helpful error message", func() {
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(string(session.Err.Contents())).To(ContainSubstring("output file must not be empty"))
+		})
+	})
+
+	Context("when output file is invalid", func() {
+		BeforeEach(func() {
+			cmd.Args = []string{getenv, "-output", outputDir}
+		})
+
+		It("fails with a helpful error message", func() {
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(string(session.Err.Contents())).To(ContainSubstring(fmt.Sprintf("cannot write to output file: '%s'", outputDir)))
+		})
+	})
+})

--- a/launcher/launcher_windows.go
+++ b/launcher/launcher_windows.go
@@ -38,7 +38,9 @@ func runProcess(dir, command string) {
 		handleErr("creating TMPDIR", err)
 	}
 
-	envs, err := profile.ProfileEnv(dir, tmpDir, getenvPath(), os.Stdout, os.Stderr)
+	getenvPath, err := getenvPath()
+	handleErr("getting getenv path failed", err)
+	envs, err := profile.ProfileEnv(dir, tmpDir, getenvPath, os.Stdout, os.Stderr)
 	handleErr("getting environment failed", err)
 
 	p, _ := syscall.GetCurrentProcess()
@@ -127,13 +129,13 @@ func createEnvBlock(envv []string) *uint16 {
 	return &utf16.Encode([]rune(string(b)))[0]
 }
 
-func getenvPath() string {
+func getenvPath() (string, error) {
 	executable, err := os.Executable()
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
 	executableDir := filepath.Dir(executable)
 
-	return filepath.Join(executableDir, "getenv.exe")
+	return filepath.Join(executableDir, "getenv.exe"), nil
 }

--- a/launcher/launcher_windows.go
+++ b/launcher/launcher_windows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"syscall"
 	"unicode/utf16"
 	"unsafe"
@@ -37,7 +38,7 @@ func runProcess(dir, command string) {
 		handleErr("creating TMPDIR", err)
 	}
 
-	envs, err := profile.ProfileEnv(dir, tmpDir, os.Stdout, os.Stderr)
+	envs, err := profile.ProfileEnv(dir, tmpDir, getenvPath(), os.Stdout, os.Stderr)
 	handleErr("getting environment failed", err)
 
 	p, _ := syscall.GetCurrentProcess()
@@ -124,4 +125,15 @@ func createEnvBlock(envv []string) *uint16 {
 	copy(b[i:i+1], []byte{0})
 
 	return &utf16.Encode([]rune(string(b)))[0]
+}
+
+func getenvPath() string {
+	executable, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+
+	executableDir := filepath.Dir(executable)
+
+	return filepath.Join(executableDir, "getenv.exe")
 }

--- a/launcher/profile/profile.go
+++ b/launcher/profile/profile.go
@@ -6,6 +6,6 @@ import (
 	"io"
 )
 
-func ProfileEnv(appDir, tempDir string, stdout io.Writer, stderr io.Writer) ([]string, error) {
+func ProfileEnv(appDir, tempDir, getenvPath string, stdout io.Writer, stderr io.Writer) ([]string, error) {
 	panic("not implemented for non-Windows OS")
 }

--- a/launcher/profile/profile_windows.go
+++ b/launcher/profile/profile_windows.go
@@ -48,7 +48,7 @@ func ProfileEnv(appDir, tempDir, getenvPath string, stdout io.Writer, stderr io.
 
 	cleanedVars := []string{}
 	if err := json.Unmarshal(out, &cleanedVars); err != nil {
-		panic(err)
+		return []string{}, fmt.Errorf("cannot unmarshal environmental variables: %s", err.Error())
 	}
 
 	return cleanedVars, nil

--- a/launcher/profile/profile_windows.go
+++ b/launcher/profile/profile_windows.go
@@ -3,6 +3,7 @@
 package profile
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,7 +14,7 @@ import (
 	"strings"
 )
 
-func ProfileEnv(appDir, tempDir string, stdout io.Writer, stderr io.Writer) ([]string, error) {
+func ProfileEnv(appDir, tempDir, getenvPath string, stdout io.Writer, stderr io.Writer) ([]string, error) {
 	fi, err := os.Stat(tempDir)
 	if err != nil {
 		return nil, fmt.Errorf("invalid temp dir: %s", err.Error())
@@ -30,7 +31,7 @@ func ProfileEnv(appDir, tempDir string, stdout io.Writer, stderr io.Writer) ([]s
 		`(for /r %i in (..\profile.d\*) do %i)`,
 		`(for /r %i in (.profile.d\*) do %i)`,
 		`(if exist .profile.bat ( .profile.bat ))`,
-		fmt.Sprintf("set > %s", envOutputFile),
+		fmt.Sprintf("%s -output %s", getenvPath, envOutputFile),
 	}
 
 	cmd := exec.Command("cmd", "/c", strings.Join(batchFileLines, " & "))
@@ -46,11 +47,8 @@ func ProfileEnv(appDir, tempDir string, stdout io.Writer, stderr io.Writer) ([]s
 	}
 
 	cleanedVars := []string{}
-	vars := strings.Split(string(out), "\n")
-	for _, v := range vars {
-		if v != "" {
-			cleanedVars = append(cleanedVars, strings.TrimSpace(v))
-		}
+	if err := json.Unmarshal(out, &cleanedVars); err != nil {
+		panic(err)
 	}
 
 	return cleanedVars, nil


### PR DESCRIPTION
This PR fixes the issue where the `launcher` would fail to start the app on Windows because of certain environmental variables passed to a Windows syscall. These environmental variables were not handled properly because they contained newline characters.

Upon discussion with @idoru and @sclevine , we decided that the most efficient way forward was to add a `getenv` binary that sanitizes the environmental variables such that the Windows syscall will handle them successfully. This design should allow us to keep iterating on env parsing separately from shared platform components.