### PR TITLE
Builder: Allow clean up to run on successful completion

### DIFF
--- a/builder/main.go
+++ b/builder/main.go
@@ -55,8 +55,6 @@ func main() {
 		println(err.Error())
 		os.Exit(buildpackapplifecycle.ExitCodeFromError(err))
 	}
-
-	os.Exit(0)
 }
 
 func usage() {

--- a/builder/main.go
+++ b/builder/main.go
@@ -46,15 +46,18 @@ func main() {
 			}
 		}
 	}
-
-	runner := buildpackrunner.New(&config)
-	defer runner.CleanUp()
-
-	_, err := runner.Run()
-	if err != nil {
+	if err := execRunner(&config); err != nil {
 		println(err.Error())
 		os.Exit(buildpackapplifecycle.ExitCodeFromError(err))
 	}
+}
+
+func execRunner(config *buildpackapplifecycle.LifecycleBuilderConfig) error {
+	runner := buildpackrunner.New(config)
+	defer runner.CleanUp()
+
+	_, err := runner.Run()
+	return err
 }
 
 func usage() {


### PR DESCRIPTION
We had our TEMP directory not cleaned up on windows2012R2 after the builder ran, because the defer wouldn't be caller when the program exits with `os.Exit`.

The are more cases to be handled (in case of failure) -- since there were some talks of refactoring,
we are just handling only the happy path in this PR.

Signed-off-by: Arjun Sreedharan <asreedharan@pivotal.io>