### PR TITLE
Allow buildpacks to specify sidecar memory limits

### DIFF
--- a/buildpackrunner/resources/launch.go
+++ b/buildpackrunner/resources/launch.go
@@ -16,6 +16,9 @@ type Process struct {
 			SidecarFor []string `yaml:"sidecar_for" json:"sidecar_for"`
 		} `yaml:"cloudfoundry" json:"cloudfoundry"`
 	} `yaml:"platforms" json:"platforms"`
+	Limits struct {
+		Memory int `yaml:"memory" json:"memory"`
+	} `yaml:"limits" json:"limits"`
 }
 
 func (p *Process) Replaceable(otherProc Process) bool {
@@ -69,6 +72,7 @@ func ConvertToResult(data LaunchData) buildpackapplifecycle.StagingResult {
 				Name:         process.Type,
 				ProcessTypes: sidecarTargets,
 				Command:      process.Command,
+				Memory:       process.Limits.Memory,
 			})
 		}
 

--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -167,7 +167,7 @@ func (runner *Runner) WriteResultJSON(resultData buildpackapplifecycle.StagingRe
 		BuildpackKey:      lastBuildpack.Key,
 		DetectedBuildpack: lastBuildpack.Name,
 		Buildpacks:        buildpacks,
-	}, )
+	})
 
 	resultPath := runner.config.OutputMetadata()
 	resultFile, err := os.Create(resultPath)

--- a/buildpackrunner/runner_test.go
+++ b/buildpackrunner/runner_test.go
@@ -124,6 +124,8 @@ processes:
   command: "do something else forever"
 - type: "oldrelic"
   command: "run new relic"
+  limits:
+    memory: 10
   platforms:
     cloudfoundry:
       sidecar_for: [ "web" ] `}
@@ -185,6 +187,7 @@ processes:
           },
 					{
             "name": "oldrelic",
+						"memory": 10,
             "process_types": [
               "web"
             ],
@@ -323,6 +326,8 @@ processes:
   command: "do something else forever"
 - type: "oldrelic"
   command: "run new relic"
+  limits:
+    memory: 10
   platforms:
     cloudfoundry:
       sidecar_for: [ "worker" ] `}
@@ -389,6 +394,7 @@ processes:
           },
           {
             "name": "oldrelic",
+						"memory": 10,
             "process_types": [
               "worker"
             ],

--- a/models.go
+++ b/models.go
@@ -55,6 +55,7 @@ type Sidecar struct {
 	Name         string   `yaml:"name" json:"name"`
 	ProcessTypes []string `yaml:"process_types" json:"process_types"`
 	Command      string   `yaml:"command" json:"command"`
+	Memory       int      `yaml:"memory,omitempty" json:"memory,omitempty"`
 }
 
 type Process struct {


### PR DESCRIPTION
Flow these limits through to the staging result returned to CAPI

This is a strawman PR to open the discussion.  Note that this_only_ allows memory limits to be specified for processes destined to be sidecars.