### PR TITLE
return error if os.Setenv fails on develop

### DIFF
--- a/credhub/credhub.go
+++ b/credhub/credhub.go
@@ -38,7 +38,9 @@ func (c *Credhub) InterpolateServiceRefs(credhubURI string) error {
 	if err != nil {
 		return fmt.Errorf("Unable to interpolate credhub references: %v", err)
 	}
-	c.os.Setenv("VCAP_SERVICES", interpolatedServices)
+	if err := c.os.Setenv("VCAP_SERVICES", interpolatedServices); err != nil {
+		return fmt.Errorf("Unable to update VCAP_SERVICES with interpolated credhub references: %v", err)
+	}
 	return nil
 }
 

--- a/credhub/credhub_test.go
+++ b/credhub/credhub_test.go
@@ -3,6 +3,7 @@ package credhub_test
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -130,6 +131,18 @@ var _ = Describe("credhub", func() {
 			It("updates VCAP_SERVICES with the interpolated content and runs the process without VCAP_PLATFORM_OPTIONS", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeOs.Getenv("VCAP_SERVICES")).To(Equal("INTERPOLATED_JSON"))
+			})
+
+			Context("when updating VCAP_SERVICES fails", func() {
+				BeforeEach(func() {
+					fakeOs.SetenvStub = func(key, value string) error {
+						return fmt.Errorf("Setenv: setting %s failed", key)
+					}
+				})
+
+				It("returns an error", func() {
+					Expect(err).To(MatchError(MatchRegexp("Unable to update VCAP_SERVICES with interpolated credhub references")))
+				})
 			})
 		})
 


### PR DESCRIPTION
- it is possible for Setenv to fail
- might be pedantic but we should have this assertion to prove nothing
  can be invalid about VCAP_SERVICES (related to user reported issues
  about VCAP_SERVICES being invalid json)