### PR TITLE
Change credhub-cli's import path

### DIFF
--- a/credhub/credhub.go
+++ b/credhub/credhub.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/buildpackapplifecycle/containerpath"
+	api "code.cloudfoundry.org/credhub-cli/credhub"
 	"code.cloudfoundry.org/goshims/osshim"
-	api "github.com/cloudfoundry-incubator/credhub-cli/credhub"
 )
 
 type Credhub struct {


### PR DESCRIPTION
The import path changed between the previously used version and version 2.7.0.