### PR TITLE
Increase the eventually timeout to 10 seconds.

### DIFF
--- a/builder/builder_suite_test.go
+++ b/builder/builder_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	paths := strings.Split(string(exePaths), "^")
 	builderPath = paths[0]
 	tarPath = paths[1]
+
+	SetDefaultEventuallyTimeout(10 * time.Second)
 })
 
 var _ = SynchronizedAfterSuite(func() {


### PR DESCRIPTION
We don't really care how long the command takes.  10 seconds should be
permissive enought to avoid any false negatives.

[#174341082](https://www.pivotaltracker.com/story/show/174341082)