### PR TITLE
Capture stderr for `tar` failures

### DIFF
--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -276,9 +276,8 @@ func (runner *Runner) GoLikeLightning() (string, string, error) {
 		return "", "", newDescriptiveError(err, "Unable to find tar executable")
 	}
 
-	err = exec.Command(tarPath, "-czf", runner.config.OutputDroplet(), "-C", runner.contentsDir, ".").Run()
-	if err != nil {
-		return "", "", newDescriptiveError(err, "Failed to compress droplet filesystem")
+	if output, err := exec.Command(tarPath, "-czf", runner.config.OutputDroplet(), "-C", runner.contentsDir, ".").CombinedOutput(); err != nil {
+		return "", "", newDescriptiveError(err, "Failed to compress droplet filesystem: %s", string(output))
 	}
 
 	//prepare the build artifacts cache output directory
@@ -287,9 +286,8 @@ func (runner *Runner) GoLikeLightning() (string, string, error) {
 		return "", "", newDescriptiveError(err, "Failed to create output build artifacts cache dir")
 	}
 
-	err = exec.Command(tarPath, "-czf", runner.config.OutputBuildArtifactsCache(), "-C", runner.config.BuildArtifactsCacheDir(), ".").Run()
-	if err != nil {
-		return "", "", newDescriptiveError(err, "Failed to compress build artifacts")
+	if output, err := exec.Command(tarPath, "-czf", runner.config.OutputBuildArtifactsCache(), "-C", runner.config.BuildArtifactsCacheDir(), ".").CombinedOutput(); err != nil {
+		return "", "", newDescriptiveError(err, "Failed to compress build artifacts: %s", string(output))
 	}
 
 	return resultJSONPath, stagingInfoYMLPath, nil


### PR DESCRIPTION
Currently, when `tar` fails it provides not annotated error similar to `Failed to compress droplet filesystem: exit status 2`

There are many errors reported with the similar error and it most cases it will be related to staging disk quota issues, e.g. https://stackoverflow.com/questions/65997099/failed-to-compress-droplet-filesystem-exit-status-2.

This fix will provide a more detailed error message and will help to better understand the root cause of the failure.

Example output:
```
2021-07-07T14:24:16.36+0200 [STG/0] ERR Failed to compress build artifacts:
2021-07-07T14:24:16.36+0200 [STG/0] ERR gzip: stdout: No space left on device
2021-07-07T14:24:16.36+0200 [STG/0] ERR /bin/tar: /tmp/output-cache: Wrote only 2048 of 10240 bytes
2021-07-07T14:24:16.36+0200 [STG/0] ERR /bin/tar: Child returned status 1
2021-07-07T14:24:16.36+0200 [STG/0] ERR /bin/tar: Error is not recoverable: exiting now
2021-07-07T14:24:16.36+0200 [STG/0] ERR : exit status 2
```