### PR TITLE
Improves tests to be more easily debuggable

### DIFF
--- a/buildpackrunner/buildpackrunner_suite_test.go
+++ b/buildpackrunner/buildpackrunner_suite_test.go
@@ -1,6 +1,7 @@
 package buildpackrunner_test
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -101,8 +102,8 @@ var _ = SynchronizedAfterSuite(func() {
 func execute(dir string, execCmd string, args ...string) {
 	cmd := exec.Command(execCmd, args...)
 	cmd.Dir = dir
-	err := cmd.Run()
-	Expect(err).NotTo(HaveOccurred())
+	output, err := cmd.CombinedOutput()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("Command failed: '%s' in directory '%s'.\nError output:\n%s\n", execCmd, dir, output))
 }
 
 func writeFile(filepath, content string) {

--- a/buildpackrunner/buildpackrunner_suite_test.go
+++ b/buildpackrunner/buildpackrunner_suite_test.go
@@ -95,7 +95,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 var _ = SynchronizedAfterSuite(func() {
 }, func() {
-	httpServer.Close()
+	if httpServer != nil {
+		httpServer.Close()
+	}
 	Expect(os.RemoveAll(tmpDir)).To(Succeed())
 })
 


### PR DESCRIPTION
When we ran these tests on a newer version of Ubuntu, we started hitting some problems pertaining to the buidlpackrunner suite, originating from [this change in Git's behavior.](https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586) The failures were confusing and did not provide much information as to what was going wrong, so we made the following improvements as we were debugging:
- Add a guard clause around closing the HTTPServer in case it's nil
- When `execute` fails, provide the output from Stdout and Stderr so that the user runnings tests can more easily see what is failing
- Use `ExpectWithOffset` to clarify _which_ command was failing.