### PR TITLE
Future proof git fixtures

### DIFF
--- a/buildpackrunner/buildpackrunner_suite_test.go
+++ b/buildpackrunner/buildpackrunner_suite_test.go
@@ -1,6 +1,7 @@
 package buildpackrunner_test
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -101,8 +102,8 @@ var _ = SynchronizedAfterSuite(func() {
 func execute(dir string, execCmd string, args ...string) {
 	cmd := exec.Command(execCmd, args...)
 	cmd.Dir = dir
-	err := cmd.Run()
-	Expect(err).NotTo(HaveOccurred())
+	output, err := cmd.CombinedOutput()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("Command failed: '%s' in directory '%s'.\nError output:\n%s\n", execCmd, dir, output))
 }
 
 func writeFile(filepath, content string) {

--- a/buildpackrunner/buildpackrunner_suite_test.go
+++ b/buildpackrunner/buildpackrunner_suite_test.go
@@ -95,7 +95,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 var _ = SynchronizedAfterSuite(func() {
 }, func() {
-	httpServer.Close()
+	if httpServer != nil {
+		httpServer.Close()
+	}
 	Expect(os.RemoveAll(tmpDir)).To(Succeed())
 })
 

--- a/buildpackrunner/buildpackrunner_suite_test.go
+++ b/buildpackrunner/buildpackrunner_suite_test.go
@@ -145,7 +145,7 @@ func downloadTar() string {
 }
 
 func fileExists(filePath string) bool {
-	if _, err := os.Stat(filePath); os.IsNotExist(err){
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return false
 	}
 	return true

--- a/buildpackrunner/git_buildpack.go
+++ b/buildpackrunner/git_buildpack.go
@@ -51,5 +51,10 @@ func performGitClone(gitPath string, args []string, branch string) error {
 		args = append(args, "-b", branch)
 	}
 	cmd := exec.Command(gitPath, args...)
-	return cmd.Run()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("git clone failed:\n%s\n%w\n", output, err)
+	}
+
+	return err
 }


### PR DESCRIPTION
Depends on first merging https://github.com/cloudfoundry/buildpackapplifecycle/pull/51

The latest versions of git require special flags in order to use `file://` schemes in git urls. (You can see a broken build caused by this problem [here](https://ci.funtime.lol/teams/diego/pipelines/diego-release/jobs/units/builds/66).) This change stops using them in test fixtures unnecessarily.