### PR TITLE
Fix windows tests

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/buildpackapplifecycle"
-	"code.cloudfoundry.org/buildpackapplifecycle/containerpath"
 	"code.cloudfoundry.org/buildpackapplifecycle/test_helpers"
 
 	. "github.com/onsi/ginkgo"
@@ -191,9 +190,8 @@ var _ = Describe("Building", func() {
 			}
 			server.HTTPTestServer.StartTLS()
 
-			cpath := containerpath.New(fixturesSslDir)
 			sessionSetEnv("USERPROFILE", fixturesSslDir)
-			if cpath.For("/") == fixturesSslDir {
+			if runtime.GOOS == "windows" {
 				// windows2012
 				sessionSetEnv("CF_INSTANCE_CERT", filepath.Join("/", "certs", "client.crt"))
 				sessionSetEnv("CF_INSTANCE_KEY", filepath.Join("/", "certs", "client.key"))

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Building", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		if runtime.GOOS == "windows" {
-			test_helpers.CopyFile(tarPath, filepath.Join(tmpDir, "tmp", "lifecycle"))
+			test_helpers.CopyFile(tarPath, filepath.Join(tmpDir, "tmp", "lifecycle", "tar.exe"))
 		}
 
 		buildpacksDir, err = ioutil.TempDir(tmpDir, "building-buildpacks")


### PR DESCRIPTION
Two changes necessary to get Windows tests to path:
- Fix the path for `tar.exe`. We believe the artifact of a bad merge commit on our part.
- Using `runtime.GOOS=="windows"` instead of `cpath.For("/") == fixturesSslDir` to determine if tests are running on Windows. When we ran these on our Windows CI worker, this code only ever fell in the `else` case. We're unsure if something has changed in the way that Windows stores these TLS certificates, or if the cpath code is buggy/outdated -- but querying the OS directly resulted in finding the TLS certificates at the correct location on Windows machines.