### PR TITLE
Bits of code clean-up

### DIFF
--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -328,23 +328,21 @@ func (runner *Runner) hasLaunchYML(selectedBuildpacks []string) bool {
 	return false
 }
 
-func (runner *Runner) buildpacksMetadata(buildpacks []string) []buildpackapplifecycle.BuildpackMetadata {
-	data := make([]buildpackapplifecycle.BuildpackMetadata, len(buildpacks))
-	for i, key := range buildpacks {
-		data[i].Key = key
+func (runner *Runner) buildpacksMetadata(buildpackKeyList []string) []buildpackapplifecycle.BuildpackMetadata {
+	buildpacksMetadataList := []buildpackapplifecycle.BuildpackMetadata{}
+
+	for i, key := range buildpackKeyList {
+		metadata := buildpackapplifecycle.BuildpackMetadata{Key: key}
+
 		configPath := filepath.Join(runner.depsDir, runner.config.DepsIndex(i), "config.yml")
 		if contents, err := ioutil.ReadFile(configPath); err == nil {
-			configyaml := struct {
-				Name    string `yaml:"name"`
-				Version string `yaml:"version"`
-			}{}
-			if err := yaml.Unmarshal(contents, &configyaml); err == nil {
-				data[i].Name = configyaml.Name
-				data[i].Version = configyaml.Version
-			}
+			yaml.Unmarshal(contents, &metadata) //nolint:errcheck
 		}
+
+		buildpacksMetadataList = append(buildpacksMetadataList, metadata)
 	}
-	return data
+
+	return buildpacksMetadataList
 }
 
 func (runner *Runner) makeDirectories() error {

--- a/buildpackrunner/runner_test.go
+++ b/buildpackrunner/runner_test.go
@@ -2,6 +2,7 @@ package buildpackrunner_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -24,6 +25,8 @@ var _ = Describe("Runner", func() {
 		var buildpacks = []string{"haskell-buildpack", "bash-buildpack"}
 		var builderConfig buildpackapplifecycle.LifecycleBuilderConfig
 
+		var defaultStartCommandFromFixtures = "This is the start command for the 'web' default process type in testdata/fake_{unix,windows}_bp/bin/release{,.bat}"
+
 		BeforeEach(func() {
 			builderConfig = makeBuilderConfig(buildpacks)
 			runner = buildpackrunner.New(&builderConfig)
@@ -40,7 +43,7 @@ var _ = Describe("Runner", func() {
 
 				stagingInfoContents, err := ioutil.ReadFile(stagingInfo)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(stagingInfoContents)).To(ContainSubstring(`{"detected_buildpack":"","start_command":"I wish I was a baller"}`))
+				Expect(string(stagingInfoContents)).To(ContainSubstring(fmt.Sprintf(`{"detected_buildpack":"","start_command":"%s"}`, defaultStartCommandFromFixtures)))
 
 				resultsJSONContents, err := os.ReadFile(resultsJSON)
 				Expect(err).ToNot(HaveOccurred())
@@ -48,9 +51,8 @@ var _ = Describe("Runner", func() {
 				actualStagingResult := buildpackapplifecycle.StagingResult{}
 				Expect(json.Unmarshal(resultsJSONContents, &actualStagingResult)).To(Succeed())
 
-				Expect(actualStagingResult.ProcessTypes).To(Equal(buildpackapplifecycle.ProcessTypes{"web": "I wish I was a baller"}))
-				Expect(actualStagingResult.ProcessList).To(Equal([]buildpackapplifecycle.Process{{Type: "web", Command: "I wish I was a baller"}}))
-				//TODO: Find the origin of the default start command "I wish I was a baller"
+				Expect(actualStagingResult.ProcessTypes).To(Equal(buildpackapplifecycle.ProcessTypes{"web": defaultStartCommandFromFixtures}))
+				Expect(actualStagingResult.ProcessList).To(Equal([]buildpackapplifecycle.Process{{Type: "web", Command: defaultStartCommandFromFixtures}}))
 			})
 		})
 
@@ -191,7 +193,7 @@ processes:
 
 				stagingInfoContents, err := ioutil.ReadFile(stagingInfo)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(stagingInfoContents)).To(ContainSubstring(`{"detected_buildpack":"","start_command":"I wish I was a baller"}`))
+				Expect(string(stagingInfoContents)).To(ContainSubstring(fmt.Sprintf(`{"detected_buildpack":"","start_command":"%s"}`, defaultStartCommandFromFixtures)))
 
 				resultsJSONContents, err := ioutil.ReadFile(resultsJSON)
 				Expect(err).ToNot(HaveOccurred())
@@ -201,12 +203,12 @@ processes:
 
 				Expect(actualStagingResult.ProcessTypes).To(Equal(buildpackapplifecycle.ProcessTypes{
 					"lightning": "go forth",
-					"web":       "I wish I was a baller",
+					"web":       defaultStartCommandFromFixtures,
 					"worker":    "do something and then quit",
 				}))
 
 				Expect(actualStagingResult.ProcessList).To(Equal([]buildpackapplifecycle.Process{
-					{Type: "web", Command: "I wish I was a baller"},
+					{Type: "web", Command: defaultStartCommandFromFixtures},
 					{Type: "worker", Command: "do something and then quit"},
 					{Type: "lightning", Command: "go forth"},
 				}))

--- a/buildpackrunner/testdata/fake_unix_bp/bin/release
+++ b/buildpackrunner/testdata/fake_unix_bp/bin/release
@@ -4,5 +4,5 @@
 cat <<EOF
 ---
 default_process_types:
-  web: "I wish I was a baller"
+  web: "This is the start command for the 'web' default process type in testdata/fake_{unix,windows}_bp/bin/release{,.bat}"
 EOF

--- a/buildpackrunner/testdata/fake_windows_bp/bin/release.bat
+++ b/buildpackrunner/testdata/fake_windows_bp/bin/release.bat
@@ -1,4 +1,4 @@
 @echo off
 echo ---
 echo default_process_types:
-echo   web: I wish I was a baller
+echo   web: This is the start command for the 'web' default process type in testdata/fake_{unix,windows}_bp/bin/release{,.bat}

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Launcher", func() {
 		}
 
 		var err error
-		extractDir, err = ioutil.TempDir("", "vcap")
+		extractDir, err = os.MkdirTemp("", "vcap")
 		Expect(err).NotTo(HaveOccurred())
 
 		appDir = filepath.Join(extractDir, "app")
@@ -147,21 +147,14 @@ var _ = Describe("Launcher", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				if runtime.GOOS == "windows" {
-					err = ioutil.WriteFile(filepath.Join(profileDir, "a.bat"), []byte("@echo off\necho sourcing a.bat\nset A=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(profileDir, "b.bat"), []byte("@echo off\necho sourcing b.bat\nset B=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(appDir, ".profile.bat"), []byte("@echo off\necho sourcing .profile.bat\nset C=%A%%B%\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(filepath.Join(profileDir, "a.bat"), []byte("@echo off\necho sourcing a.bat\nset A=1\n"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(profileDir, "b.bat"), []byte("@echo off\necho sourcing b.bat\nset B=1\n"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(appDir, ".profile.bat"), []byte("@echo off\necho sourcing .profile.bat\nset C=%A%%B%\n"), 0644)).To(Succeed())
 				} else {
-					err = ioutil.WriteFile(filepath.Join(profileDir, "a.sh"), []byte("echo sourcing a.sh\nexport A=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(profileDir, "b.sh"), []byte("echo sourcing b.sh\nexport B=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(appDir, ".profile"), []byte("echo sourcing .profile\nexport C=$A$B\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(filepath.Join(profileDir, "a.sh"), []byte("echo sourcing a.sh\nexport A=1\n"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(profileDir, "b.sh"), []byte("echo sourcing b.sh\nexport B=1\n"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(appDir, ".profile"), []byte("echo sourcing .profile\nexport C=$A$B\n"), 0644)).To(Succeed())
 				}
-
 			})
 
 			It("sources them before sourcing .profile and before executing", func() {
@@ -196,11 +189,9 @@ var _ = Describe("Launcher", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					if runtime.GOOS == "windows" {
-						err = ioutil.WriteFile(filepath.Join(profileDir, "a.bat"), []byte(fmt.Sprintf("@echo off\necho sourcing a.bat\nset PATH=%%PATH%%;%s\n", destDir)), 0644)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(os.WriteFile(filepath.Join(profileDir, "a.bat"), []byte(fmt.Sprintf("@echo off\necho sourcing a.bat\nset PATH=%%PATH%%;%s\n", destDir)), 0644)).To(Succeed())
 					} else {
-						err = ioutil.WriteFile(filepath.Join(profileDir, "a.sh"), []byte(fmt.Sprintf("echo sourcing a.sh\nexport PATH=$PATH:%s\n", destDir)), 0644)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(os.WriteFile(filepath.Join(profileDir, "a.sh"), []byte(fmt.Sprintf("echo sourcing a.sh\nexport PATH=$PATH:%s\n", destDir)), 0644)).To(Succeed())
 					}
 
 					launcherCmd.Args = []string{
@@ -250,23 +241,15 @@ var _ = Describe("Launcher", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				if runtime.GOOS == "windows" {
-					err = ioutil.WriteFile(filepath.Join(profileDir, "a.bat"), []byte("@echo off\necho sourcing a.bat\nset A=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(profileDir, "b.bat"), []byte("@echo off\necho sourcing b.bat\nset B=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = os.MkdirAll(filepath.Join(appDir, ".profile.d"), 0755)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(appDir, ".profile.d", "c.bat"), []byte("@echo off\necho sourcing c.bat\nset C=%A%%B%\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(filepath.Join(profileDir, "a.bat"), []byte("@echo off\necho sourcing a.bat\nset A=1\n"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(profileDir, "b.bat"), []byte("@echo off\necho sourcing b.bat\nset B=1\n"), 0644)).To(Succeed())
+					Expect(os.MkdirAll(filepath.Join(appDir, ".profile.d"), 0755)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(appDir, ".profile.d", "c.bat"), []byte("@echo off\necho sourcing c.bat\nset C=%A%%B%\n"), 0644)).To(Succeed())
 				} else {
-					err = ioutil.WriteFile(filepath.Join(profileDir, "a.sh"), []byte("echo sourcing a.sh\nexport A=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(profileDir, "b.sh"), []byte("echo sourcing b.sh\nexport B=1\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
-					err = os.MkdirAll(filepath.Join(appDir, ".profile.d"), 0755)
-					Expect(err).NotTo(HaveOccurred())
-					err = ioutil.WriteFile(filepath.Join(appDir, ".profile.d", "c.sh"), []byte("echo sourcing c.sh\nexport C=$A$B\n"), 0644)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(filepath.Join(profileDir, "a.sh"), []byte("echo sourcing a.sh\nexport A=1\n"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(profileDir, "b.sh"), []byte("echo sourcing b.sh\nexport B=1\n"), 0644)).To(Succeed())
+					Expect(os.MkdirAll(filepath.Join(appDir, ".profile.d"), 0755)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(appDir, ".profile.d", "c.sh"), []byte("echo sourcing c.sh\nexport C=$A$B\n"), 0644)).To(Succeed())
 				}
 			})
 
@@ -453,7 +436,7 @@ var _ = Describe("Launcher", func() {
 
 			caCerts := x509.NewCertPool()
 
-			caCertBytes, err := ioutil.ReadFile(filepath.Join(fixturesSslDir, "cacerts", "CA.crt"))
+			caCertBytes, err := os.ReadFile(filepath.Join(fixturesSslDir, "cacerts", "CA.crt"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(caCerts.AppendCertsFromPEM(caCertBytes)).To(BeTrue())
 

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -60,8 +60,7 @@ var _ = Describe("Launcher", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		appDir = filepath.Join(extractDir, "app")
-		err = os.MkdirAll(appDir, 0755)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(os.MkdirAll(appDir, 0755)).To(Succeed())
 
 		launcherCmd = &exec.Cmd{
 			Path: launcher,
@@ -127,8 +126,7 @@ var _ = Describe("Launcher", func() {
 			vcapApplicationBytes := vcapAppPattern.FindSubmatch(session.Out.Contents())[1]
 
 			vcapApplication := map[string]interface{}{}
-			err := json.Unmarshal(vcapApplicationBytes, &vcapApplication)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(json.Unmarshal(vcapApplicationBytes, &vcapApplication)).To(Succeed())
 
 			Expect(vcapApplication["host"]).To(Equal("0.0.0.0"))
 			Expect(vcapApplication["port"]).To(Equal(float64(8080)))
@@ -139,12 +137,9 @@ var _ = Describe("Launcher", func() {
 
 		Context("when the given dir has .profile.d with scripts in it", func() {
 			BeforeEach(func() {
-				var err error
-
 				profileDir := filepath.Join(appDir, ".profile.d")
 
-				err = os.MkdirAll(profileDir, 0755)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(os.MkdirAll(profileDir, 0755)).To(Succeed())
 
 				if runtime.GOOS == "windows" {
 					Expect(os.WriteFile(filepath.Join(profileDir, "a.bat"), []byte("@echo off\necho sourcing a.bat\nset A=1\n"), 0644)).To(Succeed())
@@ -174,13 +169,9 @@ var _ = Describe("Launcher", func() {
 			})
 
 			Context("hello is on path", func() {
-				var err error
-
 				BeforeEach(func() {
 					profileDir := filepath.Join(appDir, ".profile.d")
-
-					err = os.MkdirAll(profileDir, 0755)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(os.MkdirAll(profileDir, 0755)).To(Succeed())
 
 					destDir := filepath.Join(appDir, "tmp")
 					Expect(os.MkdirAll(destDir, 0777)).To(Succeed())
@@ -234,11 +225,9 @@ var _ = Describe("Launcher", func() {
 
 		Context("when the given dir has ../profile.d with scripts in it", func() {
 			BeforeEach(func() {
-				var err error
 				profileDir := filepath.Join(appDir, "..", "profile.d")
 
-				err = os.MkdirAll(profileDir, 0755)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(os.MkdirAll(profileDir, 0755)).To(Succeed())
 
 				if runtime.GOOS == "windows" {
 					Expect(os.WriteFile(filepath.Join(profileDir, "a.bat"), []byte("@echo off\necho sourcing a.bat\nset A=1\n"), 0644)).To(Succeed())

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Launcher", func() {
 	var startCommand string
 
 	removeFromLauncherEnv := func(keys ...string) {
-		newEnv := []string{}
+		var newEnv []string
 		for _, env := range launcherCmd.Env {
 			found := false
 			for _, key := range keys {

--- a/models.go
+++ b/models.go
@@ -44,9 +44,9 @@ type LifecycleMetadata struct {
 }
 
 type BuildpackMetadata struct {
-	Key     string `json:"key"`
-	Name    string `json:"name"`
-	Version string `json:"version,omitempty"`
+	Key     string `json:"key" yaml:"key"`
+	Name    string `json:"name" yaml:"name"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 type ProcessTypes map[string]string


### PR DESCRIPTION
As we're working on some changes to the `builder`, `runner`, and `launcher` code, we've found some opportunities to clean things up.

The biggest changes are organizational changes to tests (you can more easily observe the differences by running `git diff -w` to exclude whitespace changes). There are also a few updates to use more idiomatic assertions -- for example, using `Expect(cmd()).To(Succeed())` instead of `err := cmd(); Expect(err).NotTo(HaveOccurred())`.

The only change to production code modifies a function such that it uses a pre-established struct, instead of creating a local anonymous struct. Doing so did require that the struct become yaml-encodable.