### PR TITLE
Add support for configurable entrypoints

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/buildpackapplifecycle"
+	"code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner"
 	"code.cloudfoundry.org/buildpackapplifecycle/test_helpers"
 
 	. "github.com/onsi/ginkgo"
@@ -448,7 +449,7 @@ var _ = Describe("Building", func() {
 			})
 
 			It("should contain a staging_info.yml with the detected buildpack", func() {
-				stagingInfo, err := exec.Command("tar", "-xzf", outputDroplet, "-O", "./staging_info.yml").Output()
+				stagingInfo, err := exec.Command("tar", "-xzf", outputDroplet, "-O", fmt.Sprintf("./%s", buildpackrunner.DeaStagingInfoFilename)).Output()
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedYAML := `{"detected_buildpack":"Always Matching","start_command":"the start command"}`

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -699,6 +699,21 @@ var _ = Describe("Building", func() {
 						{ "key": "has-finalize", "name": "Finalize" }
 					]`))
 				})
+
+				Context("a supply outputs a config.yml with a `config:` present", func() {
+					BeforeEach(func() {
+						buildpackOrder = "has-buildpack-config"
+
+						cpBuildpack("has-buildpack-config")
+						cp(filepath.Join(appFixtures, "bash-app", "app.sh"), buildDir)
+					})
+
+					It("includes the `config:` stanza in the staging_info.yml", func() {
+						content, err := exec.Command("tar", "-xzOf", outputDroplet, "./staging_info.yml").Output()
+						Expect(err).To(BeNil())
+						Expect(string(content)).To(MatchJSON("{\"detected_buildpack\":\"Has Buildpack Config\",\"start_command\":\"the start command\",\"config\":{\"entrypoint_prefix\":\"custom-entrypoint\"}}"))
+					})
+				})
 			})
 
 			Context("final buildpack only contains finalize ", func() {

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/compile
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/compile
@@ -1,0 +1,11 @@
+#!/bin/bash
+# vim: set ft=sh
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+
+echo WOO
+env
+echo has-buildpack-config > $BUILD_DIR/compiled
+echo has-buildpack-config > $CACHE_DIR/compiled
+

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/compile
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/compile
@@ -1,5 +1,4 @@
 #!/bin/bash
-# vim: set ft=sh
 
 BUILD_DIR=$1
 CACHE_DIR=$2

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/detect
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/detect
@@ -1,5 +1,4 @@
 #!/bin/bash
-# vim: set ft=sh
 
 echo "Has Buildpack Config -- Always Matching"
 exit 0

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/detect
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/detect
@@ -1,0 +1,5 @@
+#!/bin/bash
+# vim: set ft=sh
+
+echo "Has Buildpack Config -- Always Matching"
+exit 0

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/finalize
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/finalize
@@ -1,5 +1,4 @@
 #!/bin/bash
-# vim: set ft=sh
 
 BUILD_DIR=$1
 CACHE_DIR=$2

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/finalize
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/finalize
@@ -1,0 +1,17 @@
+#!/bin/bash
+# vim: set ft=sh
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+DEP_DIR=$3
+SUB_DIR=$4
+PROFILE_D=$5
+
+echo FINALIZING
+
+contents="has-buildpack-config"
+
+echo $contents > $BUILD_DIR/finalized
+echo $contents > $CACHE_DIR/finalized
+echo $contents > $DEP_DIR/$SUB_DIR/finalized
+echo "echo $contents" > $PROFILE_D/finalized.sh

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/release
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/release
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat <<EOF
+---
+default_process_types:
+  web: the start command
+EOF

--- a/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/supply
+++ b/builder/fixtures/buildpacks/unix/has-buildpack-config/bin/supply
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+DEP_DIR=$3
+SUB_DIR=$4
+
+
+echo SUPPLYING
+
+if [ -e "$CACHE_DIR/old-supply" ]; then
+  contents=$(cat "$CACHE_DIR/old-supply")
+else
+  contents="has-buildpack-config"
+fi
+
+echo $contents > $CACHE_DIR/supplied
+echo $contents > $DEP_DIR/$SUB_DIR/supplied
+
+cat <<EOF > $DEP_DIR/$SUB_DIR/config.yml
+---
+name: Has Buildpack Config
+version: 3.14
+config:
+  entrypoint_prefix: custom-entrypoint
+EOF

--- a/buildpackrunner/dea_staging_info.go
+++ b/buildpackrunner/dea_staging_info.go
@@ -1,16 +1,14 @@
 package buildpackrunner
 
+import "code.cloudfoundry.org/buildpackapplifecycle"
+
 const DeaStagingInfoFilename = "staging_info.yml"
 
 // Used to generate YAML file read by the DEA
 type DeaStagingInfo struct {
-	DetectedBuildpack string                `json:"detected_buildpack" yaml:"detected_buildpack"`
-	StartCommand      string                `json:"start_command" yaml:"start_command"`
-	Config            *DeaStagingInfoConfig `json:"config,omitempty" yaml:"config,omitempty"`
-}
-
-type DeaStagingInfoConfig struct {
-	EntrypointPrefix string `json:"entrypoint_prefix,omitempty" yaml:"entrypoint_prefix,omitempty"`
+	DetectedBuildpack string                                 `json:"detected_buildpack" yaml:"detected_buildpack"`
+	StartCommand      string                                 `json:"start_command" yaml:"start_command"`
+	Config            *buildpackapplifecycle.BuildpackConfig `json:"config,omitempty" yaml:"config,omitempty"`
 }
 
 func (stagingInfo DeaStagingInfo) GetEntrypointPrefix() string {

--- a/buildpackrunner/dea_staging_info.go
+++ b/buildpackrunner/dea_staging_info.go
@@ -1,7 +1,22 @@
 package buildpackrunner
 
+const DeaStagingInfoFilename = "staging_info.yml"
+
 // Used to generate YAML file read by the DEA
 type DeaStagingInfo struct {
-	DetectedBuildpack string `json:"detected_buildpack" yaml:"detected_buildpack"`
-	StartCommand      string `json:"start_command" yaml:"start_command"`
+	DetectedBuildpack string                `json:"detected_buildpack" yaml:"detected_buildpack"`
+	StartCommand      string                `json:"start_command" yaml:"start_command"`
+	Config            *DeaStagingInfoConfig `json:"config,omitempty" yaml:"config,omitempty"`
+}
+
+type DeaStagingInfoConfig struct {
+	EntrypointPrefix string `json:"entrypoint_prefix,omitempty" yaml:"entrypoint_prefix,omitempty"`
+}
+
+func (stagingInfo DeaStagingInfo) GetEntrypointPrefix() string {
+	if stagingInfo.Config != nil {
+		return stagingInfo.Config.EntrypointPrefix
+	}
+
+	return ""
 }

--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -150,6 +150,7 @@ func (runner *Runner) WriteStagingInfoYML(resultData buildpackapplifecycle.Stagi
 	err = json.NewEncoder(stagingInfoFile).Encode(DeaStagingInfo{
 		DetectedBuildpack: lastBuildpack.Name,
 		StartCommand:      resultData.ProcessTypes["web"],
+		Config:            lastBuildpack.Config,
 	})
 	if err != nil {
 		return "", err

--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -135,7 +135,7 @@ func (runner *Runner) ProcessFinalBuildpack(detectedBuildpack, detectedBuildpack
 }
 
 func (runner *Runner) WriteStagingInfoYML(resultData buildpackapplifecycle.StagingResult, buildpacks []buildpackapplifecycle.BuildpackMetadata) (string, error) {
-	stagingInfoYML := filepath.Join(runner.contentsDir, "staging_info.yml")
+	stagingInfoYML := filepath.Join(runner.contentsDir, DeaStagingInfoFilename)
 	stagingInfoFile, err := os.Create(stagingInfoYML)
 	if err != nil {
 		return "", err

--- a/launcher/fixtures/custom_entrypoint/custom_entrypoint.go
+++ b/launcher/fixtures/custom_entrypoint/custom_entrypoint.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("I'm a custom entrypoint")
+	fmt.Printf("I was called with: '%s'\n", os.Args[1:])
+}

--- a/launcher/fixtures/custom_entrypoint/package.go
+++ b/launcher/fixtures/custom_entrypoint/package.go
@@ -1,0 +1,1 @@
+package main // import "code.cloudfoundry.org/buildpackapplifecycle/launcher/fixtures/custom_entrypoint"

--- a/launcher/launcher_suite_test.go
+++ b/launcher/launcher_suite_test.go
@@ -15,6 +15,7 @@ import (
 
 var launcher string
 var hello string
+var customEntrypoint string
 
 const defaultTimeout = time.Second * 5
 const defaultInterval = time.Millisecond * 100
@@ -31,19 +32,23 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	helloPath, err := gexec.Build("code.cloudfoundry.org/buildpackapplifecycle/launcher/fixtures/hello")
 	Expect(err).NotTo(HaveOccurred())
 
+	customEntrypointPath, err := gexec.Build("code.cloudfoundry.org/buildpackapplifecycle/launcher/fixtures/custom_entrypoint")
+	Expect(err).NotTo(HaveOccurred())
+
 	launcherPath := buildLauncher()
 
 	getenvPath, err := gexec.Build("code.cloudfoundry.org/buildpackapplifecycle/getenv")
 	Expect(err).NotTo(HaveOccurred())
 
-	return []byte(helloPath + "^" + launcherPath + "^" + getenvPath)
+	return []byte(helloPath + "^" + customEntrypointPath + "^" + launcherPath + "^" + getenvPath)
 }, func(exePaths []byte) {
 	paths := strings.Split(string(exePaths), "^")
 	hello = paths[0]
-	launcher = paths[1]
+	customEntrypoint = paths[1]
+	launcher = paths[2]
 
 	if runtime.GOOS == "windows" {
-		getenv := paths[2]
+		getenv := paths[3]
 
 		launcherDir := filepath.Dir(launcher)
 

--- a/launcher/launcher_unix.go
+++ b/launcher/launcher_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/launcher/launcher_unix.go
+++ b/launcher/launcher_unix.go
@@ -1,13 +1,20 @@
+//go:build !windows
 // +build !windows
 
 package main
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 )
 
-const launcher = `
+func getLauncher(entrypointPrefix string) string {
+	entryPoint := "bash -c"
+	if entrypointPrefix != "" {
+		entryPoint = entrypointPrefix
+	}
+	return fmt.Sprintf(`
 cd "$1"
 
 if [ -n "$(ls ../profile.d/* 2> /dev/null)" ]; then
@@ -28,14 +35,15 @@ fi
 
 shift
 
-exec bash -c "$@"
-`
+exec %s "$@"
+`, entryPoint)
+}
 
-func runProcess(dir, command string) {
+func runProcess(dir, command, entrypointPrefix string) {
 	syscall.Exec("/bin/bash", []string{
 		"bash",
 		"-c",
-		launcher,
+		getLauncher(entrypointPrefix),
 		os.Args[0],
 		dir,
 		command,

--- a/launcher/launcher_windows.go
+++ b/launcher/launcher_windows.go
@@ -21,7 +21,7 @@ var (
 	createProcessW = kernel32.NewProc("CreateProcessW")
 )
 
-func runProcess(dir, command string) {
+func runProcess(dir, command, _entrypoint string) {
 	err := createProcessW.Find()
 	handleErr("couldn't find func address", err)
 

--- a/models.go
+++ b/models.go
@@ -1,6 +1,8 @@
 package buildpackapplifecycle
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	DetectFailMsg          = "None of the buildpacks detected a compatible application"
@@ -44,9 +46,14 @@ type LifecycleMetadata struct {
 }
 
 type BuildpackMetadata struct {
-	Key     string `json:"key" yaml:"key"`
-	Name    string `json:"name" yaml:"name"`
-	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	Key     string           `json:"key" yaml:"key"`
+	Name    string           `json:"name" yaml:"name"`
+	Version string           `json:"version,omitempty" yaml:"version,omitempty"`
+	Config  *BuildpackConfig `json:"config,omitempty" yaml:"config,omitempty"`
+}
+
+type BuildpackConfig struct {
+	EntrypointPrefix string `json:"entrypoint_prefix,omitempty" yaml:"entrypoint_prefix,omitempty"`
 }
 
 type ProcessTypes map[string]string


### PR DESCRIPTION
## Intent
Currently, the buildpackapplifecycle always uses `exec bash -c '<start command>` to start an app. However, we want to allow buildpacks to specify a different entrypoint -- an alternative to `bash -c` -- for their apps.

## Summary of the change
This change allows buildpacks to specify an alternative during the `supply` phase, where the `supply` script can produce a `config.yml` that specifies this new entrypoint in a new `config` stanza:
```
name: Has Buildpack Config
version: 3.14
config:
  entrypoint_prefix: custom-entrypoint
```

If the buildpack specifies a custom entrypoint, then the buildpackapplfiecycle will use `exec <custom entrypoint> '<start command>'` to start the application. If the buildpack does not specify a custom entrypoint, `bash -c` is used as it always was. This change is backwards compatible.

**Also, this has only been implemented for linux applications**


### Under the hood
These commits make the following changes:
- The builder reads the new `config` stanza from `config.yml` if the buildpack's `supply` script includes it
- The builder writes the `config` stanza to the `staging_info.yml` in the final droplet, so that the custom entrypoint is available to the launcher at app start time
- The launcher uses the custom entrypoint if it is present, otherwise uses `bash -c`
- New tests and test fixtures, including a 'Has Buildpack Config' buildpack, whose `supply` executable produces a config.yml with a `config` stanza
- Moved some hard-coded magic strings into constants (e.g. `"staging_info.yml" becomes `buildpackrunner.DeaStagingInfoFilename`).


@aramprice 