### PR TITLE
Launcher: Add messages to app logs

### DIFF
--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -168,6 +168,14 @@ var _ = Describe("Launcher", func() {
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("running app"))
 			})
 
+			It("prints to the app/task logs when profile scripts are being invoked", func () {
+				Eventually(session).Should(gbytes.Say("Invoking pre-start scripts."))
+			})
+
+			It("prints to the app/task logs when the entrypoint command is being invoked", func () {
+				Eventually(session).Should(gbytes.Say("Invoking start command."))
+			})
+
 			Context("hello is on path", func() {
 				BeforeEach(func() {
 					profileDir := filepath.Join(appDir, ".profile.d")

--- a/launcher/launcher_unix.go
+++ b/launcher/launcher_unix.go
@@ -16,6 +16,8 @@ func getLauncher(entrypointPrefix string) string {
 	return fmt.Sprintf(`
 cd "$1"
 
+echo '%s'
+
 if [ -n "$(ls ../profile.d/* 2> /dev/null)" ]; then
   for env_file in ../profile.d/*; do
     source $env_file
@@ -34,8 +36,10 @@ fi
 
 shift
 
+echo '%s'
+
 exec %s "$@"
-`, entryPoint)
+`, preStartMessage, startMessage, entryPoint)
 }
 
 func runProcess(dir, command, entrypointPrefix string) {

--- a/launcher/launcher_windows.go
+++ b/launcher/launcher_windows.go
@@ -41,6 +41,8 @@ func runProcess(dir, command, _entrypoint string) {
 
 	getenvPath, err := getenvPath()
 	handleErr("getting getenv path failed", err)
+
+	fmt.Println(preStartMessage)
 	envs, err := profile.ProfileEnv(dir, tmpDir, getenvPath, os.Stdout, os.Stderr)
 	handleErr("getting environment failed", err)
 
@@ -75,6 +77,7 @@ func runProcess(dir, command, _entrypoint string) {
 	err = os.Chdir(dir)
 	handleErr("couldn't change working directory", err)
 
+	fmt.Println(startMessage)
 	creationFlags := syscall.CREATE_UNICODE_ENVIRONMENT
 	// CreateProcessW docs
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -13,6 +13,9 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+var preStartMessage = "Invoking pre-start scripts."
+var startMessage = "Invoking start command."
+
 func main() {
 	if len(os.Args) < 4 {
 		fmt.Fprintf(os.Stderr, "%s: received only %d arguments\n", os.Args[0], len(os.Args)-1)


### PR DESCRIPTION
- Print when pre-start scripts and the start command are running.
- These messages can be helpful for debugging slow and/or failing pre-start (profile) scripts or app start commands

Does this work on windows? Great question 😅