### PR TITLE
Credhub retries

### DIFF
--- a/builder/main.go
+++ b/builder/main.go
@@ -30,7 +30,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Invalid platform options: %v", err)
 		os.Exit(3)
 	} else if platformOptions != nil && platformOptions.CredhubURI != "" {
-		err = credhub.New(&osshim.OsShim{}).InterpolateServiceRefs(platformOptions.CredhubURI)
+		attempts := config.CredhubConnectAttempts()
+		delay := config.CredhubRetryDelay()
+		err = credhub.New(&osshim.OsShim{}, attempts, delay).InterpolateServiceRefs(platformOptions.CredhubURI)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to interpolate credhub refs: %v", err)
 			os.Exit(4)

--- a/builder_config.go
+++ b/builder_config.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"code.cloudfoundry.org/buildpackapplifecycle/credhub_flags"
 	"github.com/cespare/xxhash/v2"
 )
 
@@ -105,6 +107,8 @@ func NewLifecycleBuilderConfig(buildpacks []string, skipDetect bool, skipCertVer
 		skipCertVerify,
 		"skip SSL certificate verification",
 	)
+
+	credhub_flags.AddCredhubFlags(flagSet)
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -221,6 +225,14 @@ func (s LifecycleBuilderConfig) SkipCertVerify() bool {
 
 func (s LifecycleBuilderConfig) SkipDetect() bool {
 	return s.Lookup(lifecycleBuilderSkipDetect).Value.String() == "true"
+}
+
+func (s LifecycleBuilderConfig) CredhubConnectAttempts() int {
+	return credhub_flags.ConnectAttempts(s.FlagSet)
+}
+
+func (s LifecycleBuilderConfig) CredhubRetryDelay() time.Duration {
+	return credhub_flags.RetryDelay(s.FlagSet)
 }
 
 type ValidationError []error

--- a/builder_config_test.go
+++ b/builder_config_test.go
@@ -33,6 +33,8 @@ var _ = Describe("LifecycleBuilderConfig", func() {
 				"-outputBuildArtifactsCache=/tmp/output-cache",
 				"-skipCertVerify=false",
 				"-skipDetect=false",
+				"-credhubConnectAttempts=3",
+				"-credhubRetryDelay=1s",
 			}
 
 			Expect(builderConfig.Path()).To(Equal(filepath.Join(pathPrefix(), "tmp", "lifecycle", "builder")))
@@ -65,6 +67,8 @@ var _ = Describe("LifecycleBuilderConfig", func() {
 			builderConfig.Set("outputBuildArtifactsCache", "/some/cache-file")
 			builderConfig.Set("skipCertVerify", "true")
 			builderConfig.Set("skipDetect", "true")
+			builderConfig.Set("credhubConnectAttempts", "5")
+			builderConfig.Set("credhubRetryDelay", "5s")
 		})
 
 		It("generates a script for running its builder", func() {
@@ -79,6 +83,8 @@ var _ = Describe("LifecycleBuilderConfig", func() {
 				"-outputBuildArtifactsCache=/some/cache-file",
 				"-skipCertVerify=true",
 				"-skipDetect=true",
+				"-credhubConnectAttempts=5",
+				"-credhubRetryDelay=5s",
 			}
 
 			Expect(builderConfig.Path()).To(Equal(filepath.Join(pathPrefix(), "tmp", "lifecycle", "builder")))

--- a/credhub_flags/credhub_flags.go
+++ b/credhub_flags/credhub_flags.go
@@ -1,0 +1,57 @@
+package credhub_flags
+
+import (
+	"flag"
+	"time"
+)
+
+const (
+	credhubConnectAttemptsFlag    = "credhubConnectAttempts"
+	credhubRetryDelayFlag         = "credhubRetryDelay"
+	credhubConnectAttemptsDefault = 3
+	credhubRetryDelayDefault      = 1 * time.Second
+)
+
+type CredhubFlags struct {
+	*flag.FlagSet
+}
+
+func NewCredhubFlags(component string) CredhubFlags {
+	flagSet := flag.NewFlagSet(component, flag.ExitOnError)
+
+	AddCredhubFlags(flagSet)
+
+	return CredhubFlags{
+		FlagSet: flagSet,
+	}
+}
+
+func (chf CredhubFlags) ConnectAttempts() int {
+	return ConnectAttempts(chf.FlagSet)
+}
+
+func (chf CredhubFlags) RetryDelay() time.Duration {
+	return RetryDelay(chf.FlagSet)
+}
+
+func AddCredhubFlags(flagSet *flag.FlagSet) {
+	flagSet.Int(
+		credhubConnectAttemptsFlag,
+		credhubConnectAttemptsDefault,
+		"number of times that the credhub client will attempt to connect to credhub",
+	)
+
+	flagSet.Duration(
+		credhubRetryDelayFlag,
+		credhubRetryDelayDefault,
+		"delay duration that the credhub client will wait before retrying the connection to credhub",
+	)
+}
+
+func ConnectAttempts(flagSet *flag.FlagSet) int {
+	return flagSet.Lookup(credhubConnectAttemptsFlag).Value.(flag.Getter).Get().(int)
+}
+
+func RetryDelay(flagSet *flag.FlagSet) time.Duration {
+	return flagSet.Lookup(credhubRetryDelayFlag).Value.(flag.Getter).Get().(time.Duration)
+}

--- a/credhub_flags/credhub_flags_suite_test.go
+++ b/credhub_flags/credhub_flags_suite_test.go
@@ -1,0 +1,13 @@
+package credhub_flags_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCredhubFlags(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CredhubFlags Suite")
+}

--- a/credhub_flags/credhub_flags_test.go
+++ b/credhub_flags/credhub_flags_test.go
@@ -1,0 +1,68 @@
+package credhub_flags_test
+
+import (
+	"flag"
+	"time"
+
+	"code.cloudfoundry.org/buildpackapplifecycle/credhub_flags"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("credhub_flags", func() {
+
+	Context("NewCredhubFlags - for when they are the only flags", func() {
+		var flags credhub_flags.CredhubFlags
+		JustBeforeEach(func() {
+			flags = credhub_flags.NewCredhubFlags("testing")
+		})
+
+		Context("when no flags are passed", func() {
+			It("uses the defaults", func() {
+				args := []string{}
+				flags.Parse(args)
+
+				Expect(flags.ConnectAttempts()).To(Equal(3))
+				Expect(flags.RetryDelay()).To(Equal(1 * time.Second))
+			})
+		})
+
+		Context("when flags are passed", func() {
+			It("uses the provided values", func() {
+				args := []string{"-credhubConnectAttempts=5", "-credhubRetryDelay=5s"}
+				flags.Parse(args)
+
+				Expect(flags.ConnectAttempts()).To(Equal(5))
+				Expect(flags.RetryDelay()).To(Equal(5 * time.Second))
+			})
+		})
+	})
+
+	Context("AddCredhubFlags - for when you want to merge them to other flags", func() {
+		var flags *flag.FlagSet
+		JustBeforeEach(func() {
+			flags = flag.NewFlagSet("testing", flag.ExitOnError)
+			credhub_flags.AddCredhubFlags(flags)
+		})
+
+		Context("when no flags are passed", func() {
+			It("uses the defaults", func() {
+				args := []string{}
+				flags.Parse(args)
+
+				Expect(credhub_flags.ConnectAttempts(flags)).To(Equal(3))
+				Expect(credhub_flags.RetryDelay(flags)).To(Equal(1 * time.Second))
+			})
+		})
+
+		Context("when flags are passed", func() {
+			It("uses the provided values", func() {
+				args := []string{"-credhubConnectAttempts=5", "-credhubRetryDelay=5s"}
+				flags.Parse(args)
+
+				Expect(credhub_flags.ConnectAttempts(flags)).To(Equal(5))
+				Expect(credhub_flags.RetryDelay(flags)).To(Equal(5 * time.Second))
+			})
+		})
+	})
+})

--- a/env/env.go
+++ b/env/env.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"code.cloudfoundry.org/buildpackapplifecycle/credhub"
 	"code.cloudfoundry.org/buildpackapplifecycle/databaseuri"
@@ -12,7 +13,7 @@ import (
 	"code.cloudfoundry.org/goshims/osshim"
 )
 
-func CalcEnv(os osshim.Os, dir string) error {
+func CalcEnv(os osshim.Os, dir string, attempts int, delay time.Duration) error {
 	os.Setenv("HOME", dir)
 
 	tmpDir, err := filepath.Abs(filepath.Join(dir, "..", "tmp"))
@@ -51,7 +52,7 @@ func CalcEnv(os osshim.Os, dir string) error {
 	if platformOptions, err := platformoptions.Get(os.Getenv("VCAP_PLATFORM_OPTIONS")); err != nil {
 		return fmt.Errorf("Invalid platform options: %v", err)
 	} else if platformOptions != nil && platformOptions.CredhubURI != "" {
-		err := credhub.New(&osshim.OsShim{}).InterpolateServiceRefs(platformOptions.CredhubURI)
+		err := credhub.New(&osshim.OsShim{}, attempts, delay).InterpolateServiceRefs(platformOptions.CredhubURI)
 		if err != nil {
 			return fmt.Errorf("Unable to interpolate credhub refs: %v", err)
 		}

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner"
+	"code.cloudfoundry.org/buildpackapplifecycle/credhub_flags"
 	"code.cloudfoundry.org/buildpackapplifecycle/env"
 	"code.cloudfoundry.org/goshims/osshim"
 	yaml "gopkg.in/yaml.v2"
@@ -48,7 +49,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := env.CalcEnv(&osshim.OsShim{}, dir); err != nil {
+	credhubFlags := credhub_flags.NewCredhubFlags("launcher")
+	credhubFlags.Parse(os.Args[3:len(os.Args)])
+	attempts := credhubFlags.ConnectAttempts()
+	delay := credhubFlags.RetryDelay()
+
+	if err := env.CalcEnv(&osshim.OsShim{}, dir, attempts, delay); err != nil {
 		fmt.Fprint(os.Stderr, err.Error())
 		os.Exit(3)
 	}


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
WHEN an app is using a service broker that stores credentials in credhub and it is in credhub assist mode where the platform accesses those creds automatically during staging and running
AND WHEN the connection to credhub fails on the first try
THEN the request to credhub should be retried

Now it will retry credhub connections 3 times with a 1 second wait between attempts. The number of attempts and the length of delay are configurable to make sure integration tests do not take extra time. However, these configuration properties cannot currently be set by an operator or app dev.


Backward Compatibility
---------------
Breaking Change? No.
