### PR TITLE
Fix launcher_windows after catching unhandled errors on linux

### DIFF
--- a/launcher/launcher_windows.go
+++ b/launcher/launcher_windows.go
@@ -21,7 +21,7 @@ var (
 	createProcessW = kernel32.NewProc("CreateProcessW")
 )
 
-func runProcess(dir, command, _entrypoint string) {
+func runProcess(dir, command, _entrypoint string) error {
 	err := createProcessW.Find()
 	handleErr("couldn't find func address", err)
 
@@ -110,6 +110,7 @@ func runProcess(dir, command, _entrypoint string) {
 	handleErr("GetExitCodeProcess failed", err)
 
 	os.Exit(int(exitCode))
+	return nil // this function already handles errors by exiting on its own. but runProcess needs to return an error now so we just return nil at the end to avoid changing things
 }
 
 func handleErr(description string, err error) {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes the issue with compiling buildpackapplifecycle/launcher on windows after the G104 gosec updates to handle errors.


Backward Compatibility
---------------
Breaking Change? yes