### PR TITLE
Change fmt.Sprintf to satisfy go vet

### DIFF
--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -568,6 +568,7 @@ var _ = Describe("Launcher", func() {
 
 		Context("when VCAP_SERVICES contains credhub refs", func() {
 			var vcapServicesValue string
+			var vcapPlatformOptionsValue string
 
 			BeforeEach(func() {
 				vcapServicesValue = `{"my-server":[{"credentials":{"credhub-ref":"(//my-server/creds)"}}]}`
@@ -576,7 +577,8 @@ var _ = Describe("Launcher", func() {
 
 			Context("when the credhub location is passed to the launcher's platform options", func() {
 				BeforeEach(func() {
-					launcherCmd.Env = append(launcherCmd.Env, fmt.Sprintf(`VCAP_PLATFORM_OPTIONS={ "credhub-uri": "`+server.URL()+`"}`))
+					vcapPlatformOptionsValue = `{ "credhub-uri": "` + server.URL() + `"}`
+					launcherCmd.Env = append(launcherCmd.Env, fmt.Sprintf(`VCAP_PLATFORM_OPTIONS=%s`, vcapPlatformOptionsValue))
 				})
 
 				Context("when credhub successfully interpolates", func() {
@@ -664,7 +666,8 @@ var _ = Describe("Launcher", func() {
 
 			BeforeEach(func() {
 				vcapServicesValue := `{"my-server":[{"credentials":{"credhub-ref":"(//my-server/creds)"}}]}`
-				launcherCmd.Env = append(launcherCmd.Env, fmt.Sprintf(`VCAP_PLATFORM_OPTIONS={ "credhub-uri": "`+server.URL()+`"}`))
+				vcapPlatformOptionsValue := `{ "credhub-uri": "` + server.URL() + `"}`
+				launcherCmd.Env = append(launcherCmd.Env, fmt.Sprintf(`VCAP_PLATFORM_OPTIONS=%s`, vcapPlatformOptionsValue))
 				launcherCmd.Env = append(launcherCmd.Env, fmt.Sprintf("VCAP_SERVICES=%s", vcapServicesValue))
 				server.AppendHandlers(
 					ghttp.CombineHandlers(


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
go 1.24.1 introduces a check on Printf (https://github.com/golang/go/issues/60529).  This typically happens when a *printf call doesn't specify the args for the format string.  


Backward Compatibility
---------------
Breaking Change? **No**
