### PR TITLE
Fix result.json not being properly unmarshaled

### DIFF
--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 
 	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 
 	"code.cloudfoundry.org/buildpackapplifecycle"
 	"code.cloudfoundry.org/buildpackapplifecycle/buildpackrunner/resources"
@@ -345,8 +346,9 @@ func (runner *Runner) buildpacksMetadata(buildpackKeyList []string) []buildpacka
 
 		configPath := filepath.Join(runner.depsDir, runner.config.DepsIndex(i), "config.yml")
 		if contents, err := os.ReadFile(configPath); err == nil {
+			// yaml.v3 produces map[string]interface{} (vs map[interface{}]interface{} in v2), which is required for JSON marshaling of arbitrary output_metadata
 			// #nosec: G104 - we don't want to handle this for some reason
-			yaml.Unmarshal(contents, &metadata) //nolint:errcheck
+			yamlv3.Unmarshal(contents, &metadata) //nolint:errcheck
 		}
 
 		buildpacksMetadataList = append(buildpacksMetadataList, metadata)

--- a/buildpackrunner/runner.go
+++ b/buildpackrunner/runner.go
@@ -347,8 +347,11 @@ func (runner *Runner) buildpacksMetadata(buildpackKeyList []string) []buildpacka
 		configPath := filepath.Join(runner.depsDir, runner.config.DepsIndex(i), "config.yml")
 		if contents, err := os.ReadFile(configPath); err == nil {
 			// yaml.v3 produces map[string]interface{} (vs map[interface{}]interface{} in v2), which is required for JSON marshaling of arbitrary output_metadata
-			// #nosec: G104 - we don't want to handle this for some reason
-			yamlv3.Unmarshal(contents, &metadata) //nolint:errcheck
+			if yamlErr := yamlv3.Unmarshal(contents, &metadata); yamlErr != nil {
+				fmt.Fprintf(os.Stderr, "Failed to unmarshal buildpack metadata for buildpack key %s: %s", key, yamlErr.Error())
+			}
+		} else {
+			fmt.Fprintf(os.Stdout, "Failed to read buildpack config.yml for buildpack key %s: %s", key, err.Error())
 		}
 
 		buildpacksMetadataList = append(buildpacksMetadataList, metadata)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
when testing #78 with more complex metadata I hit an issue where output_metadata  unmarshaled by yaml.v2 as map[interface{}]interface{}, which encoding/json cannot marshal. This caused WriteResultJSON to silently fail, leaving result.json empty.

Switch to yaml.v3 for config.yml parsing, which produces map[string]interface{} that JSON handles correctly.

I only changed this usage of yaml to v3 for now

Backward Compatibility
---------------
Breaking Change? No
